### PR TITLE
feat: tg-68 add gplay updater

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -58,9 +58,14 @@ dependencies {
     implementation(libs.okhttp)
     implementation(libs.timber)
     implementation(libs.filekit.dialogs)
+    implementation(libs.material)
 
     // Crashlytics ships in the gplay flavor only — the fdroid flavor never pulls in
     // this proprietary dependency, only a no-op CrashReporter implementation.
     gplayImplementation(project.dependencies.platform(libs.firebase.bom))
     gplayImplementation(libs.firebase.crashlytics)
+
+    // Play In-App Updates ship in the gplay flavor only — the fdroid flavor never pulls in
+    // this proprietary dependency, only a no-op AppUpdateChecker implementation.
+    gplayImplementation(libs.google.inapp.update.ktx)
 }

--- a/androidApp/src/fdroid/kotlin/com/grappim/taigamobile/data/AppUpdateCheckerImpl.kt
+++ b/androidApp/src/fdroid/kotlin/com/grappim/taigamobile/data/AppUpdateCheckerImpl.kt
@@ -1,0 +1,17 @@
+package com.grappim.taigamobile.data
+
+import android.app.Activity
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import org.koin.core.annotation.Single
+
+@Single(binds = [AppUpdateChecker::class])
+class AppUpdateCheckerImpl : AppUpdateChecker {
+    override val updateState: Flow<UpdateState> = flowOf()
+
+    override fun checkAndRequestUpdate(activity: Activity) = Unit
+    override fun checkUpdateStateOnResume() = Unit
+    override fun registerUpdateListener() = Unit
+    override fun unregisterUpdateListener() = Unit
+    override fun completeUpdate() = Unit
+}

--- a/androidApp/src/gplay/kotlin/com/grappim/taigamobile/data/AppUpdateCheckerImpl.kt
+++ b/androidApp/src/gplay/kotlin/com/grappim/taigamobile/data/AppUpdateCheckerImpl.kt
@@ -1,0 +1,77 @@
+package com.grappim.taigamobile.data
+
+import android.app.Activity
+import android.content.Context
+import com.google.android.play.core.appupdate.AppUpdateManager
+import com.google.android.play.core.appupdate.AppUpdateManagerFactory
+import com.google.android.play.core.appupdate.AppUpdateOptions
+import com.google.android.play.core.install.InstallStateUpdatedListener
+import com.google.android.play.core.install.model.AppUpdateType
+import com.google.android.play.core.install.model.InstallStatus
+import com.google.android.play.core.install.model.UpdateAvailability
+import com.google.android.play.core.ktx.installStatus
+import com.google.android.play.core.ktx.isFlexibleUpdateAllowed
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import org.koin.core.annotation.Single
+
+@Single(binds = [AppUpdateChecker::class])
+class AppUpdateCheckerImpl(
+    private val context: Context
+) : AppUpdateChecker {
+
+    private val appUpdateManager: AppUpdateManager by lazy {
+        AppUpdateManagerFactory.create(context)
+    }
+
+    private val _updateState = MutableSharedFlow<UpdateState>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+    override val updateState: Flow<UpdateState> = _updateState.asSharedFlow()
+
+    override fun checkAndRequestUpdate(activity: Activity) {
+        appUpdateManager.appUpdateInfo.addOnSuccessListener { info ->
+            if (info.installStatus == InstallStatus.DOWNLOADED) {
+                _updateState.tryEmit(UpdateState.UpdateDownloaded)
+                return@addOnSuccessListener
+            }
+            val isUpdateAvailable = info.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE
+            if (isUpdateAvailable && info.isFlexibleUpdateAllowed) {
+                appUpdateManager.startUpdateFlow(
+                    info,
+                    activity,
+                    AppUpdateOptions.newBuilder(AppUpdateType.FLEXIBLE).build()
+                )
+            }
+        }
+    }
+
+    override fun checkUpdateStateOnResume() {
+        appUpdateManager.appUpdateInfo.addOnSuccessListener { info ->
+            if (info.installStatus == InstallStatus.DOWNLOADED) {
+                _updateState.tryEmit(UpdateState.UpdateDownloaded)
+            }
+        }
+    }
+
+    override fun completeUpdate() {
+        appUpdateManager.completeUpdate()
+    }
+
+    override fun registerUpdateListener() {
+        appUpdateManager.registerListener(installStateUpdatedListener)
+    }
+
+    override fun unregisterUpdateListener() {
+        appUpdateManager.unregisterListener(installStateUpdatedListener)
+    }
+
+    private val installStateUpdatedListener = InstallStateUpdatedListener { state ->
+        if (state.installStatus == InstallStatus.DOWNLOADED) {
+            _updateState.tryEmit(UpdateState.UpdateDownloaded)
+        }
+    }
+}

--- a/androidApp/src/main/kotlin/com/grappim/taigamobile/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/grappim/taigamobile/MainActivity.kt
@@ -5,14 +5,23 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.lifecycle.lifecycleScope
+import com.google.android.material.snackbar.Snackbar
+import com.grappim.taigamobile.data.AppUpdateChecker
+import com.grappim.taigamobile.data.UpdateState
 import com.grappim.taigamobile.main.TaigaAppContent
 import com.grappim.taigamobile.uikit.utils.ScreenReadySignalController
 import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.dialogs.init
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import org.koin.android.ext.android.inject
 
 class MainActivity : ComponentActivity() {
 
     private val screenReadySignalController = ScreenReadySignalController()
+
+    private val appUpdateChecker: AppUpdateChecker by inject()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen().apply {
@@ -24,8 +33,43 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         FileKit.init(this)
 
+        appUpdateChecker.checkAndRequestUpdate(this)
+        observeUpdateState()
+
         setContent {
             TaigaAppContent(screenReadySignalController)
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        appUpdateChecker.registerUpdateListener()
+        appUpdateChecker.checkUpdateStateOnResume()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        appUpdateChecker.unregisterUpdateListener()
+    }
+
+    private fun observeUpdateState() {
+        lifecycleScope.launch {
+            appUpdateChecker.updateState.collectLatest { state ->
+                when (state) {
+                    is UpdateState.UpdateDownloaded -> showRestartSnackbar()
+                }
+            }
+        }
+    }
+
+    private fun showRestartSnackbar() {
+        Snackbar.make(
+            window.decorView.rootView,
+            getString(R.string.app_update_downloaded),
+            Snackbar.LENGTH_INDEFINITE
+        ).apply {
+            setAction(getString(R.string.restart)) { appUpdateChecker.completeUpdate() }
+            show()
         }
     }
 }

--- a/androidApp/src/main/kotlin/com/grappim/taigamobile/data/AppUpdateChecker.kt
+++ b/androidApp/src/main/kotlin/com/grappim/taigamobile/data/AppUpdateChecker.kt
@@ -1,0 +1,18 @@
+package com.grappim.taigamobile.data
+
+import android.app.Activity
+import kotlinx.coroutines.flow.Flow
+
+interface AppUpdateChecker {
+    val updateState: Flow<UpdateState>
+
+    fun checkAndRequestUpdate(activity: Activity)
+    fun checkUpdateStateOnResume()
+    fun registerUpdateListener()
+    fun unregisterUpdateListener()
+    fun completeUpdate()
+}
+
+sealed class UpdateState {
+    data object UpdateDownloaded : UpdateState()
+}

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -2,4 +2,6 @@
 <resources>
     <string name="app_name" translatable="false">Taiga Mobile</string>
     <string name="app_name_debug" translatable="false">Dbg Taiga Mobile</string>
+    <string name="app_update_downloaded">An update has just been downloaded</string>
+    <string name="restart">Restart</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -107,6 +107,8 @@ firebase-bom = "34.15.0"
 google-services = "4.5.0"
 # https://firebase.google.com/docs/crashlytics/android/get-started
 firebase-crashlytics-plugin = "3.0.7"
+# https://developer.android.com/guide/playcore#in-app-updates
+in-app-update = "2.1.0"
 
 [libraries]
 filekit-dialogs = { module = "io.github.vinceglb:filekit-dialogs", version.ref = "filekit" }
@@ -202,6 +204,8 @@ timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
 
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebase-bom" }
 firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }
+
+google-inapp-update-ktx = { module = "com.google.android.play:app-update-ktx", version.ref = "in-app-update" }
 
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 


### PR DESCRIPTION
### Be sure to run locally
1. `./gradlew ktlintFormat`
2. `./gradlew jvmTest`
3. `./gradlew :androidApp:assembleFdroidDebug`

### Describe your changes

<!-- Thank you for your Pull Request. Please provide a description above. -->

### Additional Information

Adds a Google Play In-App Update checker, **gplay flavor only**, following the same `data.CrashReporterImpl` gplay/fdroid split already used for Crashlytics. The fdroid flavor gets a no-op `AppUpdateCheckerImpl` and never depends on `com.google.android.play:app-update-ktx`.

#### Proof: the fdroid build contains no Google/Firebase/Play code

**1. Dependency graph — `app-update-ktx` and `firebase-crashlytics` are absent from `fdroidDebugRuntimeClasspath`, present only in `gplayDebugRuntimeClasspath`:**

```
$ ./gradlew :androidApp:dependencies --configuration fdroidDebugRuntimeClasspath -q | grep -iE "firebase|crashlytics|app-update"
(no output)

$ ./gradlew :androidApp:dependencies --configuration gplayDebugRuntimeClasspath -q | grep -iE "firebase|crashlytics|app-update"
+--- com.google.firebase:firebase-bom:34.15.0
+--- com.google.firebase:firebase-crashlytics -> 20.0.6
+--- com.google.android.play:app-update-ktx:2.1.0
     +--- com.google.android.play:app-update:2.1.0
... (full firebase-crashlytics + app-update transitive trees)
```

**2. Built APK — scanned all `classes*.dex` in the assembled `app-fdroid-debug.apk` for any `com/google/*` type references:**

```
$ ./gradlew :androidApp:assembleFdroidDebug
$ unzip -o app-fdroid-debug.apk "classes*.dex" -d dex
$ strings dex/*.dex | grep -oE "com/google/[a-z0-9_]+(/[a-z0-9_]+)?" | sort -u
com/google/accompanist/drawablepainter
com/google/android/material
com/google/common/util
com/google/errorprone/annotations
```

Only pre-existing, open-source (Apache 2.0) libraries are present — Compose Accompanist, Material Components, Guava, and compile-time-only error-prone annotations. None of these talk to any Google network service.

Explicit checks for the packages F-Droid disallows, all zero matches in the fdroid APK:

```
com/google/firebase        -> 0 matches
com/google/android/gms     -> 0 matches
com/google/android/play    -> 0 matches
com/crashlytics            -> 0 matches
```

**3. Merged manifest** — the only `com.google.android.gms.*` string in the fdroid manifest is a disabled (`android:enabled="false"`) `ModuleDependencies` placeholder service used to declare the backported Android Photo Picker, contributed by the pre-existing `io.github.vinceglb:filekit-dialogs-android` dependency (unrelated to this PR, confirmed via the manifest merger blame report). It registers no real component and makes no calls to Play services.

Net result: `assembleFdroidDebug` produces a build with zero Firebase/Crashlytics/Play Core code or manifest entries, exactly as required for F-Droid.