### PR TITLE
fix: tg-112, error messages on api errors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,12 @@ feature/{name}/
 
 For DI patterns, the `expect/actual @Configuration` rule, module registry, qualifier map, and troubleshooting, see the **koin-expert** subagent (`.claude/agents/koin-expert.md`). Never use KSP — this project uses `io.insert-koin.compiler.plugin` exclusively.
 
+## KMP String Resources
+
+`strings.xml` (`strings/src/commonMain/composeResources/values/`) does not need Android-style
+apostrophe/quote escaping (`\'`) — Compose Multiplatform's resource loader doesn't apply AAPT's
+escaping rules, so plain `'` works correctly. Don't escape apostrophes in new strings.
+
 ## uikit Components
 
 For available Composable components, theme tokens, TopBarController usage, drag-and-drop, and offline/permission UI patterns, see the **uikit-guide** subagent (`.claude/agents/uikit-guide.md`). Consult it before creating any new widget.

--- a/composeApp/src/commonMain/kotlin/com/grappim/taigamobile/nav/SettingsNavGraph.kt
+++ b/composeApp/src/commonMain/kotlin/com/grappim/taigamobile/nav/SettingsNavGraph.kt
@@ -29,6 +29,9 @@ import com.grappim.taigamobile.feature.settings.ui.modules.navigateToModules
 import com.grappim.taigamobile.feature.settings.ui.projectdetails.ProjectDetailsNavDestination
 import com.grappim.taigamobile.feature.settings.ui.projectdetails.ProjectDetailsScreen
 import com.grappim.taigamobile.feature.settings.ui.projectdetails.navigateToProjectDetails
+import com.grappim.taigamobile.feature.settings.ui.trustedcerts.TrustedCertificatesNavDestination
+import com.grappim.taigamobile.feature.settings.ui.trustedcerts.TrustedCertificatesScreen
+import com.grappim.taigamobile.feature.settings.ui.trustedcerts.goToTrustedCertificatesScreen
 import com.grappim.taigamobile.feature.settings.ui.user.SettingsUserScreen
 import com.grappim.taigamobile.feature.settings.ui.user.SettingsUserScreenNavDestination
 import com.grappim.taigamobile.feature.settings.ui.user.goToSettingsUserScreen
@@ -54,6 +57,9 @@ fun NavGraphBuilder.settingsNavGraph(navController: NavHostController, showSnack
             },
             goToModulesScreen = {
                 navController.navigateToModules()
+            },
+            goToTrustedCertificatesScreen = {
+                navController.goToTrustedCertificatesScreen()
             }
         )
     }
@@ -109,5 +115,9 @@ fun NavGraphBuilder.settingsNavGraph(navController: NavHostController, showSnack
 
     composable<ProjectValuesNavDestination> {
         ProjectValuesScreen(showSnackbar = showSnackbar)
+    }
+
+    composable<TrustedCertificatesNavDestination> {
+        TrustedCertificatesScreen()
     }
 }

--- a/core/api/src/androidMain/kotlin/com/grappim/taigamobile/core/api/CompositeTrustManager.kt
+++ b/core/api/src/androidMain/kotlin/com/grappim/taigamobile/core/api/CompositeTrustManager.kt
@@ -1,0 +1,132 @@
+package com.grappim.taigamobile.core.api
+
+import com.grappim.taigamobile.core.domain.CertificateHostnameMismatchException
+import com.grappim.taigamobile.core.domain.PendingCertTrust
+import com.grappim.taigamobile.core.domain.UntrustedCertificateException
+import com.grappim.taigamobile.core.storage.cert.TrustedCertStorage
+import kotlinx.coroutines.runBlocking
+import java.net.Socket
+import java.security.MessageDigest
+import java.security.cert.CertificateException
+import java.security.cert.X509Certificate
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import javax.net.ssl.SSLEngine
+import javax.net.ssl.SSLSocket
+import javax.net.ssl.X509ExtendedTrustManager
+import javax.net.ssl.X509TrustManager
+
+class CompositeTrustManager(
+    private val defaultTrustManager: X509TrustManager,
+    private val trustedCertStorage: TrustedCertStorage
+) : X509ExtendedTrustManager() {
+
+    override fun checkClientTrusted(chain: Array<out X509Certificate>, authType: String) {
+        defaultTrustManager.checkClientTrusted(chain, authType)
+    }
+
+    override fun checkClientTrusted(chain: Array<out X509Certificate>, authType: String, socket: Socket) {
+        defaultTrustManager.checkClientTrusted(chain, authType)
+    }
+
+    override fun checkClientTrusted(chain: Array<out X509Certificate>, authType: String, engine: SSLEngine) {
+        defaultTrustManager.checkClientTrusted(chain, authType)
+    }
+
+    override fun checkServerTrusted(chain: Array<out X509Certificate>, authType: String) {
+        checkServerTrusted(chain, authType, host = null)
+    }
+
+    override fun checkServerTrusted(chain: Array<out X509Certificate>, authType: String, socket: Socket) {
+        val host = (socket as? SSLSocket)?.handshakeSession?.peerHost
+        checkServerTrusted(chain, authType, host)
+    }
+
+    override fun checkServerTrusted(chain: Array<out X509Certificate>, authType: String, engine: SSLEngine) {
+        checkServerTrusted(chain, authType, engine.peerHost)
+    }
+
+    // Exposed with an explicit host param (rather than only the SSLSocket/SSLEngine overrides above)
+    // so the pinning decision itself is testable without a real socket/engine.
+    internal fun checkServerTrusted(chain: Array<out X509Certificate>, authType: String, host: String?) {
+        val leaf = chain.firstOrNull() ?: throw CertificateException("Empty certificate chain")
+
+        // checkServerTrusted is a synchronous JSSE callback with no suspension point, so a pinned-cert
+        // lookup has to block here rather than making this whole call chain suspend.
+        val isPinned = host != null && runBlocking { trustedCertStorage.isTrusted(host, sha256Fingerprint(leaf)) }
+        if (isPinned) {
+            leaf.checkValidity()
+            return
+        }
+
+        try {
+            defaultTrustManager.checkServerTrusted(chain, authType)
+        } catch (e: CertificateException) {
+            // Without a host there's nothing to offer trust-on-first-use for, so let the original
+            // failure propagate unchanged instead of wrapping it.
+            if (host == null) throw e
+            // Pinning a cert whose CN/SAN doesn't cover this host would never let a connection
+            // actually succeed (hostname verification runs separately, after this check, and
+            // would still reject it) — so don't offer TOFU for it, surface a clear error instead.
+            if (!hostMatchesCertificate(host, leaf)) {
+                throw CertificateHostnameMismatchException(
+                    "Certificate presented for $host does not match its subject/SAN entries",
+                    e
+                )
+            }
+            throw UntrustedCertificateException(pendingCertTrust(host, leaf), e)
+        }
+    }
+
+    override fun getAcceptedIssuers(): Array<X509Certificate> = defaultTrustManager.acceptedIssuers
+
+    private fun pendingCertTrust(host: String, certificate: X509Certificate): PendingCertTrust = PendingCertTrust(
+        host = host,
+        subject = certificate.subjectX500Principal.name,
+        issuer = certificate.issuerX500Principal.name,
+        notBefore = formatDate(certificate.notBefore),
+        notAfter = formatDate(certificate.notAfter),
+        sha256Fingerprint = sha256Fingerprint(certificate)
+    )
+
+    private fun formatDate(date: Date): String = SimpleDateFormat("yyyy-MM-dd", Locale.US).format(date)
+
+    private fun hostMatchesCertificate(host: String, certificate: X509Certificate): Boolean {
+        val sanValues = runCatching { certificate.subjectAlternativeNames }.getOrNull().orEmpty()
+            .mapNotNull { entry ->
+                val type = entry.getOrNull(0) as? Int
+                (entry.getOrNull(1) as? String).takeIf { type == SAN_DNS_NAME || type == SAN_IP_ADDRESS }
+            }
+        if (sanValues.isNotEmpty()) return sanValues.any { matchesHostname(host, it) }
+
+        // No SANs present: fall back to the certificate's CN, common for self-signed certs that
+        // predate SAN-based hostname verification.
+        val commonName = certificate.subjectX500Principal.name
+            .split(",")
+            .map { it.trim() }
+            .firstOrNull { it.startsWith("CN=", ignoreCase = true) }
+            ?.substringAfter("=")
+        return commonName != null && matchesHostname(host, commonName)
+    }
+
+    private fun matchesHostname(host: String, pattern: String): Boolean = when {
+        pattern.equals(host, ignoreCase = true) -> true
+
+        pattern.startsWith("*.") ->
+            host.length > pattern.length - 1 &&
+                host.endsWith(pattern.substring(1), ignoreCase = true)
+
+        else -> false
+    }
+
+    private companion object {
+        const val SAN_DNS_NAME = 2
+        const val SAN_IP_ADDRESS = 7
+    }
+}
+
+fun sha256Fingerprint(certificate: X509Certificate): String {
+    val digest = MessageDigest.getInstance("SHA-256").digest(certificate.encoded)
+    return digest.joinToString(":") { byte -> "%02X".format(byte) }
+}

--- a/core/api/src/androidMain/kotlin/com/grappim/taigamobile/core/api/PlatformHttpClientEngine.kt
+++ b/core/api/src/androidMain/kotlin/com/grappim/taigamobile/core/api/PlatformHttpClientEngine.kt
@@ -1,0 +1,29 @@
+package com.grappim.taigamobile.core.api
+
+import com.grappim.taigamobile.core.storage.cert.TrustedCertStorage
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.okhttp.OkHttp
+import java.security.KeyStore
+import javax.net.ssl.SSLContext
+import javax.net.ssl.TrustManager
+import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509TrustManager
+
+actual fun createPlatformHttpClientEngine(trustedCertStorage: TrustedCertStorage): HttpClientEngine {
+    val trustManager = CompositeTrustManager(defaultSystemTrustManager(), trustedCertStorage)
+    val sslContext = SSLContext.getInstance("TLS").apply {
+        init(null, arrayOf<TrustManager>(trustManager), null)
+    }
+
+    return OkHttp.create {
+        config {
+            sslSocketFactory(sslContext.socketFactory, trustManager)
+        }
+    }
+}
+
+private fun defaultSystemTrustManager(): X509TrustManager {
+    val factory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+    factory.init(null as KeyStore?)
+    return factory.trustManagers.filterIsInstance<X509TrustManager>().first()
+}

--- a/core/api/src/commonMain/kotlin/com/grappim/taigamobile/core/api/KmpNetworkModule.kt
+++ b/core/api/src/commonMain/kotlin/com/grappim/taigamobile/core/api/KmpNetworkModule.kt
@@ -6,6 +6,7 @@ import com.grappim.taigamobile.core.api.errors.NetworkErrorMapper
 import com.grappim.taigamobile.core.appinfoapi.AppInfoProvider
 import com.grappim.taigamobile.core.logger.logcat
 import com.grappim.taigamobile.core.storage.auth.AuthStorage
+import com.grappim.taigamobile.core.storage.cert.TrustedCertStorage
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
@@ -48,8 +49,9 @@ class KmpNetworkModule {
         baseUrlProvider: BaseUrlProvider,
         appInfoProvider: AppInfoProvider,
         networkErrorMapper: NetworkErrorMapper,
-        errorResponseParser: ErrorResponseParser
-    ): HttpClient = HttpClient {
+        errorResponseParser: ErrorResponseParser,
+        trustedCertStorage: TrustedCertStorage
+    ): HttpClient = HttpClient(createPlatformHttpClientEngine(trustedCertStorage)) {
         expectSuccess = false
         defaultRequest {
             contentType(ContentType.Application.Json)
@@ -87,8 +89,9 @@ class KmpNetworkModule {
         appInfoProvider: AppInfoProvider,
         tokenRefresher: TokenRefresher,
         networkErrorMapper: NetworkErrorMapper,
-        errorResponseParser: ErrorResponseParser
-    ): HttpClient = HttpClient {
+        errorResponseParser: ErrorResponseParser,
+        trustedCertStorage: TrustedCertStorage
+    ): HttpClient = HttpClient(createPlatformHttpClientEngine(trustedCertStorage)) {
         expectSuccess = false
         defaultRequest {
             contentType(ContentType.Application.Json)

--- a/core/api/src/commonMain/kotlin/com/grappim/taigamobile/core/api/PlatformHttpClientEngine.kt
+++ b/core/api/src/commonMain/kotlin/com/grappim/taigamobile/core/api/PlatformHttpClientEngine.kt
@@ -1,0 +1,6 @@
+package com.grappim.taigamobile.core.api
+
+import com.grappim.taigamobile.core.storage.cert.TrustedCertStorage
+import io.ktor.client.engine.HttpClientEngine
+
+expect fun createPlatformHttpClientEngine(trustedCertStorage: TrustedCertStorage): HttpClientEngine

--- a/core/api/src/commonMain/kotlin/com/grappim/taigamobile/core/api/errors/ErrorMappingPlugin.kt
+++ b/core/api/src/commonMain/kotlin/com/grappim/taigamobile/core/api/errors/ErrorMappingPlugin.kt
@@ -2,6 +2,8 @@ package com.grappim.taigamobile.core.api.errors
 
 import com.grappim.taigamobile.core.domain.NetworkException
 import com.grappim.taigamobile.core.domain.ProjectLimitInfo
+import com.grappim.taigamobile.core.logger.LogPriority
+import com.grappim.taigamobile.core.logger.logcat
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.HttpClientPlugin
 import io.ktor.client.plugins.HttpSend
@@ -64,6 +66,9 @@ class ErrorMappingPlugin(
                 } catch (e: NetworkException) {
                     throw e
                 } catch (e: Exception) {
+                    logcat(priority = LogPriority.ERROR, tag = "ErrorMappingPlugin", throwable = e) {
+                        "Request to ${request.url} failed"
+                    }
                     throw plugin.networkErrorMapper.mapToNetworkException(e)
                 }
             }

--- a/core/api/src/commonMain/kotlin/com/grappim/taigamobile/core/api/errors/ErrorMappingPlugin.kt
+++ b/core/api/src/commonMain/kotlin/com/grappim/taigamobile/core/api/errors/ErrorMappingPlugin.kt
@@ -67,7 +67,7 @@ class ErrorMappingPlugin(
                     throw e
                 } catch (e: Exception) {
                     logcat(priority = LogPriority.ERROR, tag = "ErrorMappingPlugin", throwable = e) {
-                        "Request to ${request.url} failed"
+                        "Request failed"
                     }
                     throw plugin.networkErrorMapper.mapToNetworkException(e)
                 }

--- a/core/api/src/commonMain/kotlin/com/grappim/taigamobile/core/api/errors/NetworkErrorMapper.kt
+++ b/core/api/src/commonMain/kotlin/com/grappim/taigamobile/core/api/errors/NetworkErrorMapper.kt
@@ -2,7 +2,9 @@ package com.grappim.taigamobile.core.api.errors
 
 import com.grappim.taigamobile.core.domain.NetworkException
 import com.grappim.taigamobile.core.domain.PlatformIOException
-import com.grappim.taigamobile.core.domain.mapPlatformNetworkErrorCode
+import com.grappim.taigamobile.core.domain.PlatformNetworkError
+import com.grappim.taigamobile.core.domain.UntrustedCertificateNetworkException
+import com.grappim.taigamobile.core.domain.mapPlatformNetworkError
 import io.ktor.client.network.sockets.SocketTimeoutException
 import io.ktor.http.HttpStatusCode
 import org.koin.core.annotation.Single
@@ -22,12 +24,19 @@ class NetworkErrorMapper {
     }
 
     fun mapToNetworkException(e: Exception): Throwable {
-        val platformErrorCode = mapPlatformNetworkErrorCode(e)
+        val platformError = mapPlatformNetworkError(e)
         return when {
             e is NetworkException -> e
+
             e is SocketTimeoutException -> NetworkException(NetworkException.ERROR_TIMEOUT)
-            platformErrorCode != null -> NetworkException(platformErrorCode)
+
+            platformError is PlatformNetworkError.UntrustedCertificate ->
+                UntrustedCertificateNetworkException(platformError.pendingCertTrust)
+
+            platformError is PlatformNetworkError.Code -> NetworkException(platformError.errorCode)
+
             e is PlatformIOException -> NetworkException(NetworkException.ERROR_NETWORK_IO)
+
             else -> NetworkException(NetworkException.ERROR_UNDEFINED)
         }
     }

--- a/core/api/src/commonMain/kotlin/com/grappim/taigamobile/core/api/errors/NetworkErrorMapper.kt
+++ b/core/api/src/commonMain/kotlin/com/grappim/taigamobile/core/api/errors/NetworkErrorMapper.kt
@@ -2,6 +2,7 @@ package com.grappim.taigamobile.core.api.errors
 
 import com.grappim.taigamobile.core.domain.NetworkException
 import com.grappim.taigamobile.core.domain.PlatformIOException
+import com.grappim.taigamobile.core.domain.mapPlatformNetworkErrorCode
 import io.ktor.client.network.sockets.SocketTimeoutException
 import io.ktor.http.HttpStatusCode
 import org.koin.core.annotation.Single
@@ -20,10 +21,14 @@ class NetworkErrorMapper {
         else -> NetworkException.ERROR_HTTP_EXCEPTION
     }
 
-    fun mapToNetworkException(e: Exception): Throwable = when (e) {
-        is NetworkException -> e
-        is SocketTimeoutException -> NetworkException(NetworkException.ERROR_TIMEOUT)
-        is PlatformIOException -> NetworkException(NetworkException.ERROR_NETWORK_IO)
-        else -> NetworkException(NetworkException.ERROR_UNDEFINED)
+    fun mapToNetworkException(e: Exception): Throwable {
+        val platformErrorCode = mapPlatformNetworkErrorCode(e)
+        return when {
+            e is NetworkException -> e
+            e is SocketTimeoutException -> NetworkException(NetworkException.ERROR_TIMEOUT)
+            platformErrorCode != null -> NetworkException(platformErrorCode)
+            e is PlatformIOException -> NetworkException(NetworkException.ERROR_NETWORK_IO)
+            else -> NetworkException(NetworkException.ERROR_UNDEFINED)
+        }
     }
 }

--- a/core/api/src/iosMain/kotlin/com/grappim/taigamobile/core/api/PlatformHttpClientEngine.kt
+++ b/core/api/src/iosMain/kotlin/com/grappim/taigamobile/core/api/PlatformHttpClientEngine.kt
@@ -1,0 +1,7 @@
+package com.grappim.taigamobile.core.api
+
+import com.grappim.taigamobile.core.storage.cert.TrustedCertStorage
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.darwin.Darwin
+
+actual fun createPlatformHttpClientEngine(trustedCertStorage: TrustedCertStorage): HttpClientEngine = Darwin.create()

--- a/core/api/src/jvmMain/kotlin/com/grappim/taigamobile/core/api/CompositeTrustManager.kt
+++ b/core/api/src/jvmMain/kotlin/com/grappim/taigamobile/core/api/CompositeTrustManager.kt
@@ -1,0 +1,133 @@
+package com.grappim.taigamobile.core.api
+
+import com.grappim.taigamobile.core.domain.CertificateHostnameMismatchException
+import com.grappim.taigamobile.core.domain.PendingCertTrust
+import com.grappim.taigamobile.core.domain.UntrustedCertificateException
+import com.grappim.taigamobile.core.storage.cert.TrustedCertStorage
+import kotlinx.coroutines.runBlocking
+import java.net.Socket
+import java.security.MessageDigest
+import java.security.cert.CertificateException
+import java.security.cert.X509Certificate
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import javax.net.ssl.SSLEngine
+import javax.net.ssl.SSLSocket
+import javax.net.ssl.X509ExtendedTrustManager
+import javax.net.ssl.X509TrustManager
+
+@Suppress("CustomX509TrustManager")
+class CompositeTrustManager(
+    private val defaultTrustManager: X509TrustManager,
+    private val trustedCertStorage: TrustedCertStorage
+) : X509ExtendedTrustManager() {
+
+    override fun checkClientTrusted(chain: Array<out X509Certificate>, authType: String) {
+        defaultTrustManager.checkClientTrusted(chain, authType)
+    }
+
+    override fun checkClientTrusted(chain: Array<out X509Certificate>, authType: String, socket: Socket) {
+        defaultTrustManager.checkClientTrusted(chain, authType)
+    }
+
+    override fun checkClientTrusted(chain: Array<out X509Certificate>, authType: String, engine: SSLEngine) {
+        defaultTrustManager.checkClientTrusted(chain, authType)
+    }
+
+    override fun checkServerTrusted(chain: Array<out X509Certificate>, authType: String) {
+        checkServerTrusted(chain, authType, host = null)
+    }
+
+    override fun checkServerTrusted(chain: Array<out X509Certificate>, authType: String, socket: Socket) {
+        val host = (socket as? SSLSocket)?.handshakeSession?.peerHost
+        checkServerTrusted(chain, authType, host)
+    }
+
+    override fun checkServerTrusted(chain: Array<out X509Certificate>, authType: String, engine: SSLEngine) {
+        checkServerTrusted(chain, authType, engine.peerHost)
+    }
+
+    // Exposed with an explicit host param (rather than only the SSLSocket/SSLEngine overrides above)
+    // so the pinning decision itself is testable without a real socket/engine.
+    internal fun checkServerTrusted(chain: Array<out X509Certificate>, authType: String, host: String?) {
+        val leaf = chain.firstOrNull() ?: throw CertificateException("Empty certificate chain")
+
+        // checkServerTrusted is a synchronous JSSE callback with no suspension point, so a pinned-cert
+        // lookup has to block here rather than making this whole call chain suspend.
+        val isPinned = host != null && runBlocking { trustedCertStorage.isTrusted(host, sha256Fingerprint(leaf)) }
+        if (isPinned) {
+            leaf.checkValidity()
+            return
+        }
+
+        try {
+            defaultTrustManager.checkServerTrusted(chain, authType)
+        } catch (e: CertificateException) {
+            // Without a host there's nothing to offer trust-on-first-use for, so let the original
+            // failure propagate unchanged instead of wrapping it.
+            if (host == null) throw e
+            // Pinning a cert whose CN/SAN doesn't cover this host would never let a connection
+            // actually succeed (hostname verification runs separately, after this check, and
+            // would still reject it) — so don't offer TOFU for it, surface a clear error instead.
+            if (!hostMatchesCertificate(host, leaf)) {
+                throw CertificateHostnameMismatchException(
+                    "Certificate presented for $host does not match its subject/SAN entries",
+                    e
+                )
+            }
+            throw UntrustedCertificateException(pendingCertTrust(host, leaf), e)
+        }
+    }
+
+    override fun getAcceptedIssuers(): Array<X509Certificate> = defaultTrustManager.acceptedIssuers
+
+    private fun pendingCertTrust(host: String, certificate: X509Certificate): PendingCertTrust = PendingCertTrust(
+        host = host,
+        subject = certificate.subjectX500Principal.name,
+        issuer = certificate.issuerX500Principal.name,
+        notBefore = formatDate(certificate.notBefore),
+        notAfter = formatDate(certificate.notAfter),
+        sha256Fingerprint = sha256Fingerprint(certificate)
+    )
+
+    private fun formatDate(date: Date): String = SimpleDateFormat("yyyy-MM-dd", Locale.US).format(date)
+
+    private fun hostMatchesCertificate(host: String, certificate: X509Certificate): Boolean {
+        val sanValues = runCatching { certificate.subjectAlternativeNames }.getOrNull().orEmpty()
+            .mapNotNull { entry ->
+                val type = entry.getOrNull(0) as? Int
+                (entry.getOrNull(1) as? String).takeIf { type == SAN_DNS_NAME || type == SAN_IP_ADDRESS }
+            }
+        if (sanValues.isNotEmpty()) return sanValues.any { matchesHostname(host, it) }
+
+        // No SANs present: fall back to the certificate's CN, common for self-signed certs that
+        // predate SAN-based hostname verification.
+        val commonName = certificate.subjectX500Principal.name
+            .split(",")
+            .map { it.trim() }
+            .firstOrNull { it.startsWith("CN=", ignoreCase = true) }
+            ?.substringAfter("=")
+        return commonName != null && matchesHostname(host, commonName)
+    }
+
+    private fun matchesHostname(host: String, pattern: String): Boolean = when {
+        pattern.equals(host, ignoreCase = true) -> true
+
+        pattern.startsWith("*.") ->
+            host.length > pattern.length - 1 &&
+                host.endsWith(pattern.substring(1), ignoreCase = true)
+
+        else -> false
+    }
+
+    private companion object {
+        const val SAN_DNS_NAME = 2
+        const val SAN_IP_ADDRESS = 7
+    }
+}
+
+fun sha256Fingerprint(certificate: X509Certificate): String {
+    val digest = MessageDigest.getInstance("SHA-256").digest(certificate.encoded)
+    return digest.joinToString(":") { byte -> "%02X".format(byte) }
+}

--- a/core/api/src/jvmMain/kotlin/com/grappim/taigamobile/core/api/PlatformHttpClientEngine.kt
+++ b/core/api/src/jvmMain/kotlin/com/grappim/taigamobile/core/api/PlatformHttpClientEngine.kt
@@ -1,0 +1,29 @@
+package com.grappim.taigamobile.core.api
+
+import com.grappim.taigamobile.core.storage.cert.TrustedCertStorage
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.okhttp.OkHttp
+import java.security.KeyStore
+import javax.net.ssl.SSLContext
+import javax.net.ssl.TrustManager
+import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509TrustManager
+
+actual fun createPlatformHttpClientEngine(trustedCertStorage: TrustedCertStorage): HttpClientEngine {
+    val trustManager = CompositeTrustManager(defaultSystemTrustManager(), trustedCertStorage)
+    val sslContext = SSLContext.getInstance("TLS").apply {
+        init(null, arrayOf<TrustManager>(trustManager), null)
+    }
+
+    return OkHttp.create {
+        config {
+            sslSocketFactory(sslContext.socketFactory, trustManager)
+        }
+    }
+}
+
+private fun defaultSystemTrustManager(): X509TrustManager {
+    val factory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+    factory.init(null as KeyStore?)
+    return factory.trustManagers.filterIsInstance<X509TrustManager>().first()
+}

--- a/core/api/src/jvmTest/kotlin/com/grappim/taigamobile/core/api/CompositeTrustManagerTest.kt
+++ b/core/api/src/jvmTest/kotlin/com/grappim/taigamobile/core/api/CompositeTrustManagerTest.kt
@@ -1,0 +1,189 @@
+package com.grappim.taigamobile.core.api
+
+import com.grappim.taigamobile.core.domain.CertificateHostnameMismatchException
+import com.grappim.taigamobile.core.domain.PendingCertTrust
+import com.grappim.taigamobile.core.domain.UntrustedCertificateException
+import com.grappim.taigamobile.testing.storage.FakeTrustedCertStorage
+import kotlinx.coroutines.test.runTest
+import java.security.cert.CertificateException
+import java.security.cert.CertificateExpiredException
+import java.util.Date
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class CompositeTrustManagerTest {
+
+    private val certA = FakeX509Certificate(byteArrayOf(1, 2, 3))
+    private val certB = FakeX509Certificate(byteArrayOf(4, 5, 6))
+
+    private fun createSut(
+        defaultTrustManager: FakeX509TrustManager = FakeX509TrustManager(),
+        trustedCertStorage: FakeTrustedCertStorage = FakeTrustedCertStorage()
+    ) = CompositeTrustManager(defaultTrustManager, trustedCertStorage)
+
+    private suspend fun FakeTrustedCertStorage.trust(host: String, sha256Fingerprint: String) {
+        trust(
+            PendingCertTrust(
+                host = host,
+                subject = "CN=$host",
+                issuer = "CN=Test CA",
+                notBefore = "2026-01-01",
+                notAfter = "2027-01-01",
+                sha256Fingerprint = sha256Fingerprint
+            )
+        )
+    }
+
+    @Test
+    fun `unpinned cert delegates to the default trust manager`() = runTest {
+        val defaultTrustManager = FakeX509TrustManager(serverTrustedThrows = false)
+        val sut = createSut(defaultTrustManager = defaultTrustManager)
+
+        sut.checkServerTrusted(arrayOf(certA), "RSA", "taiga.example.com")
+
+        assertTrue(defaultTrustManager.checkServerTrustedCalled)
+    }
+
+    @Test
+    fun `unpinned cert rejected by the default trust manager throws`() = runTest {
+        val sut = createSut(defaultTrustManager = FakeX509TrustManager(serverTrustedThrows = true))
+
+        assertFailsWith<CertificateException> {
+            sut.checkServerTrusted(arrayOf(certA), "RSA", "taiga.example.com")
+        }
+    }
+
+    @Test
+    fun `unpinned cert with a known host is wrapped with the presented cert's details for TOFU`() = runTest {
+        val sut = createSut(defaultTrustManager = FakeX509TrustManager(serverTrustedThrows = true))
+
+        val exception = assertFailsWith<UntrustedCertificateException> {
+            sut.checkServerTrusted(arrayOf(certA), "RSA", "taiga.example.com")
+        }
+
+        assertEquals("taiga.example.com", exception.pendingCertTrust.host)
+        assertEquals(sha256Fingerprint(certA), exception.pendingCertTrust.sha256Fingerprint)
+    }
+
+    @Test
+    fun `pinned host and fingerprint is trusted without consulting the default trust manager`() = runTest {
+        val trustedCertStorage = FakeTrustedCertStorage()
+        trustedCertStorage.trust("taiga.example.com", sha256Fingerprint(certA))
+        val defaultTrustManager = FakeX509TrustManager(serverTrustedThrows = true)
+        val sut = createSut(defaultTrustManager = defaultTrustManager, trustedCertStorage = trustedCertStorage)
+
+        sut.checkServerTrusted(arrayOf(certA), "RSA", "taiga.example.com")
+
+        assertTrue(!defaultTrustManager.checkServerTrustedCalled)
+    }
+
+    @Test
+    fun `pin for one host does not trust a different host presenting the same certificate`() = runTest {
+        val trustedCertStorage = FakeTrustedCertStorage()
+        trustedCertStorage.trust("taiga.example.com", sha256Fingerprint(certA))
+        val sut = createSut(
+            defaultTrustManager = FakeX509TrustManager(serverTrustedThrows = true),
+            trustedCertStorage = trustedCertStorage
+        )
+
+        assertFailsWith<CertificateException> {
+            sut.checkServerTrusted(arrayOf(certA), "RSA", "other.example.com")
+        }
+    }
+
+    @Test
+    fun `pin for a host does not trust a different certificate presented by that same host`() = runTest {
+        val trustedCertStorage = FakeTrustedCertStorage()
+        trustedCertStorage.trust("taiga.example.com", sha256Fingerprint(certA))
+        val sut = createSut(
+            defaultTrustManager = FakeX509TrustManager(serverTrustedThrows = true),
+            trustedCertStorage = trustedCertStorage
+        )
+
+        assertFailsWith<CertificateException> {
+            sut.checkServerTrusted(arrayOf(certB), "RSA", "taiga.example.com")
+        }
+    }
+
+    @Test
+    fun `pinned but expired certificate still throws instead of being silently trusted`() = runTest {
+        val expiredCert = FakeX509Certificate(
+            encodedBytes = byteArrayOf(7, 8, 9),
+            notBefore = Date(0),
+            notAfter = Date(1)
+        )
+        val trustedCertStorage = FakeTrustedCertStorage()
+        trustedCertStorage.trust("taiga.example.com", sha256Fingerprint(expiredCert))
+        val sut = createSut(
+            defaultTrustManager = FakeX509TrustManager(serverTrustedThrows = true),
+            trustedCertStorage = trustedCertStorage
+        )
+
+        assertFailsWith<CertificateExpiredException> {
+            sut.checkServerTrusted(arrayOf(expiredCert), "RSA", "taiga.example.com")
+        }
+    }
+
+    @Test
+    fun `null host cannot be pinned and always falls back to the default trust manager`() = runTest {
+        val trustedCertStorage = FakeTrustedCertStorage()
+        trustedCertStorage.trust("taiga.example.com", sha256Fingerprint(certA))
+        val defaultTrustManager = FakeX509TrustManager(serverTrustedThrows = true)
+        val sut = createSut(defaultTrustManager = defaultTrustManager, trustedCertStorage = trustedCertStorage)
+
+        assertFailsWith<CertificateException> {
+            sut.checkServerTrusted(arrayOf(certA), "RSA", host = null)
+        }
+        assertTrue(defaultTrustManager.checkServerTrustedCalled)
+    }
+
+    @Test
+    fun `null host failure is not wrapped since there's no host to offer TOFU for`() = runTest {
+        val sut = createSut(defaultTrustManager = FakeX509TrustManager(serverTrustedThrows = true))
+
+        val exception = assertFailsWith<CertificateException> {
+            sut.checkServerTrusted(arrayOf(certA), "RSA", host = null)
+        }
+
+        assertFalse(exception is UntrustedCertificateException)
+    }
+
+    @Test
+    fun `unpinned cert whose CN does not cover the connecting host is not offered for TOFU`() = runTest {
+        val cert = FakeX509Certificate(byteArrayOf(9, 9, 9), commonName = "other-host.example.com")
+        val sut = createSut(defaultTrustManager = FakeX509TrustManager(serverTrustedThrows = true))
+
+        assertFailsWith<CertificateHostnameMismatchException> {
+            sut.checkServerTrusted(arrayOf(cert), "RSA", "taiga.example.com")
+        }
+    }
+
+    @Test
+    fun `unpinned cert with a SAN IP matching the connecting host is still offered for TOFU`() = runTest {
+        val cert = FakeX509Certificate(
+            byteArrayOf(9, 9, 9),
+            subjectAlternativeNames = listOf(listOf(7, "192.168.0.241"))
+        )
+        val sut = createSut(defaultTrustManager = FakeX509TrustManager(serverTrustedThrows = true))
+
+        assertFailsWith<UntrustedCertificateException> {
+            sut.checkServerTrusted(arrayOf(cert), "RSA", "192.168.0.241")
+        }
+    }
+
+    @Test
+    fun `unpinned cert with a SAN IP not matching the connecting host is not offered for TOFU`() = runTest {
+        val cert = FakeX509Certificate(
+            byteArrayOf(9, 9, 9),
+            subjectAlternativeNames = listOf(listOf(7, "192.168.0.241"))
+        )
+        val sut = createSut(defaultTrustManager = FakeX509TrustManager(serverTrustedThrows = true))
+
+        assertFailsWith<CertificateHostnameMismatchException> {
+            sut.checkServerTrusted(arrayOf(cert), "RSA", "192.168.0.248")
+        }
+    }
+}

--- a/core/api/src/jvmTest/kotlin/com/grappim/taigamobile/core/api/FakeX509Certificate.kt
+++ b/core/api/src/jvmTest/kotlin/com/grappim/taigamobile/core/api/FakeX509Certificate.kt
@@ -1,0 +1,66 @@
+package com.grappim.taigamobile.core.api
+
+import java.math.BigInteger
+import java.security.Principal
+import java.security.PublicKey
+import java.security.cert.CertificateExpiredException
+import java.security.cert.CertificateNotYetValidException
+import java.security.cert.X509Certificate
+import java.util.Date
+import javax.security.auth.x500.X500Principal
+
+/**
+ * Minimal [X509Certificate] double for tests. Only [getEncoded] (used for fingerprinting) and
+ * [checkValidity] (driven by [notBefore]/[notAfter]) are meaningful — everything else this class
+ * doesn't otherwise need is stubbed since [X509Certificate] has no lighter-weight fake in the JDK.
+ */
+@Suppress("OVERRIDE_DEPRECATION")
+class FakeX509Certificate(
+    private val encodedBytes: ByteArray,
+    private val notBefore: Date = Date(0),
+    private val notAfter: Date = Date(Long.MAX_VALUE / 2),
+    private val commonName: String = "taiga.example.com",
+    private val subjectAlternativeNames: List<List<Any>>? = null
+) : X509Certificate() {
+
+    override fun checkValidity() = checkValidity(Date())
+
+    override fun checkValidity(date: Date) {
+        if (date.before(notBefore)) throw CertificateNotYetValidException()
+        if (date.after(notAfter)) throw CertificateExpiredException()
+    }
+
+    override fun getVersion(): Int = 3
+    override fun getSerialNumber(): BigInteger = BigInteger.ONE
+    override fun getIssuerDN(): Principal = Principal { "CN=Fake Issuer" }
+    override fun getSubjectDN(): Principal = Principal { "CN=Fake Subject" }
+
+    // The JDK's default getSubjectX500Principal()/getIssuerX500Principal() re-parse the real
+    // certificate bytes from getEncoded() (via sun.security.x509.X509CertImpl), which fails for
+    // this fake's non-DER encodedBytes — override directly instead of relying on that reparsing.
+    override fun getIssuerX500Principal(): X500Principal = X500Principal("CN=Fake Issuer")
+    override fun getSubjectX500Principal(): X500Principal = X500Principal("CN=$commonName")
+    override fun getSubjectAlternativeNames(): Collection<List<Any>>? = subjectAlternativeNames
+    override fun getNotBefore(): Date = notBefore
+    override fun getNotAfter(): Date = notAfter
+    override fun getTBSCertificate(): ByteArray = encodedBytes
+    override fun getSignature(): ByteArray = ByteArray(0)
+    override fun getSigAlgName(): String = "SHA256withRSA"
+    override fun getSigAlgOID(): String = "1.2.840.113549.1.1.11"
+    override fun getSigAlgParams(): ByteArray? = null
+    override fun getIssuerUniqueID(): BooleanArray? = null
+    override fun getSubjectUniqueID(): BooleanArray? = null
+    override fun getKeyUsage(): BooleanArray? = null
+    override fun getBasicConstraints(): Int = -1
+
+    override fun hasUnsupportedCriticalExtension(): Boolean = false
+    override fun getCriticalExtensionOIDs(): Set<String> = emptySet()
+    override fun getNonCriticalExtensionOIDs(): Set<String> = emptySet()
+    override fun getExtensionValue(oid: String?): ByteArray? = null
+
+    override fun getEncoded(): ByteArray = encodedBytes
+    override fun verify(key: PublicKey?) = Unit
+    override fun verify(key: PublicKey?, sigProvider: String?) = Unit
+    override fun toString(): String = "FakeX509Certificate"
+    override fun getPublicKey(): PublicKey? = null
+}

--- a/core/api/src/jvmTest/kotlin/com/grappim/taigamobile/core/api/FakeX509TrustManager.kt
+++ b/core/api/src/jvmTest/kotlin/com/grappim/taigamobile/core/api/FakeX509TrustManager.kt
@@ -1,0 +1,19 @@
+package com.grappim.taigamobile.core.api
+
+import java.security.cert.CertificateException
+import java.security.cert.X509Certificate
+import javax.net.ssl.X509TrustManager
+
+class FakeX509TrustManager(private val serverTrustedThrows: Boolean = true) : X509TrustManager {
+
+    var checkServerTrustedCalled = false
+
+    override fun checkClientTrusted(chain: Array<out X509Certificate>, authType: String) = Unit
+
+    override fun checkServerTrusted(chain: Array<out X509Certificate>, authType: String) {
+        checkServerTrustedCalled = true
+        if (serverTrustedThrows) throw CertificateException("untrusted")
+    }
+
+    override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+}

--- a/core/api/src/jvmTest/kotlin/com/grappim/taigamobile/core/api/errors/NetworkErrorMapperJvmTest.kt
+++ b/core/api/src/jvmTest/kotlin/com/grappim/taigamobile/core/api/errors/NetworkErrorMapperJvmTest.kt
@@ -1,8 +1,13 @@
 package com.grappim.taigamobile.core.api.errors
 
+import com.grappim.taigamobile.core.domain.CertificateHostnameMismatchException
 import com.grappim.taigamobile.core.domain.NetworkException
+import com.grappim.taigamobile.core.domain.PendingCertTrust
+import com.grappim.taigamobile.core.domain.UntrustedCertificateException
+import com.grappim.taigamobile.core.domain.UntrustedCertificateNetworkException
 import java.net.UnknownHostException
 import javax.net.ssl.SSLHandshakeException
+import javax.net.ssl.SSLPeerUnverifiedException
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -33,4 +38,52 @@ class NetworkErrorMapperJvmTest {
 
         assertEquals(NetworkException.ERROR_HOST_NOT_FOUND, (result as NetworkException).errorCode)
     }
+
+    @Test
+    fun `mapToNetworkException unwraps an UntrustedCertificateException into UntrustedCertificateNetworkException`() {
+        val pendingCertTrust = PendingCertTrust(
+            host = "taiga.example.com",
+            subject = "CN=taiga.example.com",
+            issuer = "CN=Home Lab CA",
+            notBefore = "2026-01-01",
+            notAfter = "2027-01-01",
+            sha256Fingerprint = "AA:BB:CC"
+        )
+        val cause = UntrustedCertificateException(pendingCertTrust, CertificateExceptionStub())
+        val e = SSLHandshakeException("certificate not trusted").apply { initCause(cause) }
+
+        val result = sut.mapToNetworkException(e)
+
+        assertEquals(pendingCertTrust, (result as UntrustedCertificateNetworkException).pendingCertTrust)
+    }
+
+    @Test
+    fun `mapToNetworkException with a plain SSLHandshakeException still falls back to ERROR_SSL_CERTIFICATE`() {
+        val e = SSLHandshakeException("certificate not trusted").apply { initCause(RuntimeException("unrelated")) }
+
+        val result = sut.mapToNetworkException(e)
+
+        assertEquals(NetworkException.ERROR_SSL_CERTIFICATE, (result as NetworkException).errorCode)
+    }
+
+    @Test
+    fun `mapToNetworkException with SSLPeerUnverifiedException returns ERROR_SSL_HOSTNAME_MISMATCH`() {
+        val e = SSLPeerUnverifiedException("Hostname 192.168.0.248 not verified")
+
+        val result = sut.mapToNetworkException(e)
+
+        assertEquals(NetworkException.ERROR_SSL_HOSTNAME_MISMATCH, (result as NetworkException).errorCode)
+    }
+
+    @Test
+    fun `mapToNetworkException unwraps a CertificateHostnameMismatchException into ERROR_SSL_HOSTNAME_MISMATCH`() {
+        val cause = CertificateHostnameMismatchException("host mismatch", CertificateExceptionStub())
+        val e = SSLHandshakeException("certificate not trusted").apply { initCause(cause) }
+
+        val result = sut.mapToNetworkException(e)
+
+        assertEquals(NetworkException.ERROR_SSL_HOSTNAME_MISMATCH, (result as NetworkException).errorCode)
+    }
 }
+
+private class CertificateExceptionStub : java.security.cert.CertificateException("untrusted")

--- a/core/api/src/jvmTest/kotlin/com/grappim/taigamobile/core/api/errors/NetworkErrorMapperJvmTest.kt
+++ b/core/api/src/jvmTest/kotlin/com/grappim/taigamobile/core/api/errors/NetworkErrorMapperJvmTest.kt
@@ -1,0 +1,36 @@
+package com.grappim.taigamobile.core.api.errors
+
+import com.grappim.taigamobile.core.domain.NetworkException
+import java.net.UnknownHostException
+import javax.net.ssl.SSLHandshakeException
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class NetworkErrorMapperJvmTest {
+
+    private lateinit var sut: NetworkErrorMapper
+
+    @BeforeTest
+    fun setup() {
+        sut = NetworkErrorMapper()
+    }
+
+    @Test
+    fun `mapToNetworkException with SSLHandshakeException returns NetworkException with ERROR_SSL_CERTIFICATE`() {
+        val e = SSLHandshakeException("certificate not trusted")
+
+        val result = sut.mapToNetworkException(e)
+
+        assertEquals(NetworkException.ERROR_SSL_CERTIFICATE, (result as NetworkException).errorCode)
+    }
+
+    @Test
+    fun `mapToNetworkException with UnknownHostException returns NetworkException with ERROR_HOST_NOT_FOUND`() {
+        val e = UnknownHostException("taiga.example.com")
+
+        val result = sut.mapToNetworkException(e)
+
+        assertEquals(NetworkException.ERROR_HOST_NOT_FOUND, (result as NetworkException).errorCode)
+    }
+}

--- a/core/domain/src/androidMain/kotlin/com/grappim/taigamobile/core/domain/CertificateHostnameMismatchException.kt
+++ b/core/domain/src/androidMain/kotlin/com/grappim/taigamobile/core/domain/CertificateHostnameMismatchException.kt
@@ -1,0 +1,11 @@
+package com.grappim.taigamobile.core.domain
+
+import java.security.cert.CertificateException
+
+/**
+ * Thrown by the composite trust manager when the presented certificate's CN/SAN entries don't
+ * cover the host being connected to. Distinct from [UntrustedCertificateException] so
+ * [mapPlatformNetworkError] can route it to a clear "wrong host" message instead of offering a
+ * trust-on-first-use dialog that could never result in a working connection.
+ */
+class CertificateHostnameMismatchException(message: String, cause: Throwable) : CertificateException(message, cause)

--- a/core/domain/src/androidMain/kotlin/com/grappim/taigamobile/core/domain/PlatformNetworkErrorMapper.android.kt
+++ b/core/domain/src/androidMain/kotlin/com/grappim/taigamobile/core/domain/PlatformNetworkErrorMapper.android.kt
@@ -2,9 +2,22 @@ package com.grappim.taigamobile.core.domain
 
 import java.net.UnknownHostException
 import javax.net.ssl.SSLHandshakeException
+import javax.net.ssl.SSLPeerUnverifiedException
 
-actual fun mapPlatformNetworkErrorCode(exception: Exception): Int? = when (exception) {
-    is SSLHandshakeException -> NetworkException.ERROR_SSL_CERTIFICATE
-    is UnknownHostException -> NetworkException.ERROR_HOST_NOT_FOUND
+actual fun mapPlatformNetworkError(exception: Exception): PlatformNetworkError? = when {
+    exception is SSLHandshakeException && exception.cause is UntrustedCertificateException ->
+        PlatformNetworkError.UntrustedCertificate(
+            (exception.cause as UntrustedCertificateException).pendingCertTrust
+        )
+
+    exception is SSLHandshakeException && exception.cause is CertificateHostnameMismatchException ->
+        PlatformNetworkError.Code(NetworkException.ERROR_SSL_HOSTNAME_MISMATCH)
+
+    exception is SSLHandshakeException -> PlatformNetworkError.Code(NetworkException.ERROR_SSL_CERTIFICATE)
+
+    exception is SSLPeerUnverifiedException -> PlatformNetworkError.Code(NetworkException.ERROR_SSL_HOSTNAME_MISMATCH)
+
+    exception is UnknownHostException -> PlatformNetworkError.Code(NetworkException.ERROR_HOST_NOT_FOUND)
+
     else -> null
 }

--- a/core/domain/src/androidMain/kotlin/com/grappim/taigamobile/core/domain/PlatformNetworkErrorMapper.android.kt
+++ b/core/domain/src/androidMain/kotlin/com/grappim/taigamobile/core/domain/PlatformNetworkErrorMapper.android.kt
@@ -1,0 +1,10 @@
+package com.grappim.taigamobile.core.domain
+
+import java.net.UnknownHostException
+import javax.net.ssl.SSLHandshakeException
+
+actual fun mapPlatformNetworkErrorCode(exception: Exception): Int? = when (exception) {
+    is SSLHandshakeException -> NetworkException.ERROR_SSL_CERTIFICATE
+    is UnknownHostException -> NetworkException.ERROR_HOST_NOT_FOUND
+    else -> null
+}

--- a/core/domain/src/androidMain/kotlin/com/grappim/taigamobile/core/domain/UntrustedCertificateException.kt
+++ b/core/domain/src/androidMain/kotlin/com/grappim/taigamobile/core/domain/UntrustedCertificateException.kt
@@ -1,0 +1,12 @@
+package com.grappim.taigamobile.core.domain
+
+import java.security.cert.CertificateException
+
+/**
+ * Thrown by the composite trust manager instead of the plain [CertificateException] a default
+ * trust manager would throw, so the presented certificate's details survive the
+ * SSLHandshakeException wrapping all the way up to [mapPlatformNetworkError] and can be shown to
+ * the user instead of a generic failure.
+ */
+class UntrustedCertificateException(val pendingCertTrust: PendingCertTrust, cause: Throwable) :
+    CertificateException(cause)

--- a/core/domain/src/commonMain/kotlin/com/grappim/taigamobile/core/domain/NetworkException.kt
+++ b/core/domain/src/commonMain/kotlin/com/grappim/taigamobile/core/domain/NetworkException.kt
@@ -37,5 +37,6 @@ class NetworkException(val errorCode: Int, val request: String? = "", val taigaE
         const val ERROR_INTERNAL_SERVER = -19
         const val ERROR_CONFLICT = -20
         const val ERROR_LOCKED = -21
+        const val ERROR_SSL_CERTIFICATE = -22
     }
 }

--- a/core/domain/src/commonMain/kotlin/com/grappim/taigamobile/core/domain/NetworkException.kt
+++ b/core/domain/src/commonMain/kotlin/com/grappim/taigamobile/core/domain/NetworkException.kt
@@ -38,5 +38,6 @@ class NetworkException(val errorCode: Int, val request: String? = "", val taigaE
         const val ERROR_CONFLICT = -20
         const val ERROR_LOCKED = -21
         const val ERROR_SSL_CERTIFICATE = -22
+        const val ERROR_SSL_HOSTNAME_MISMATCH = -23
     }
 }

--- a/core/domain/src/commonMain/kotlin/com/grappim/taigamobile/core/domain/PendingCertTrust.kt
+++ b/core/domain/src/commonMain/kotlin/com/grappim/taigamobile/core/domain/PendingCertTrust.kt
@@ -1,0 +1,13 @@
+package com.grappim.taigamobile.core.domain
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PendingCertTrust(
+    val host: String,
+    val subject: String,
+    val issuer: String,
+    val notBefore: String,
+    val notAfter: String,
+    val sha256Fingerprint: String
+)

--- a/core/domain/src/commonMain/kotlin/com/grappim/taigamobile/core/domain/PlatformNetworkError.kt
+++ b/core/domain/src/commonMain/kotlin/com/grappim/taigamobile/core/domain/PlatformNetworkError.kt
@@ -1,0 +1,8 @@
+package com.grappim.taigamobile.core.domain
+
+sealed class PlatformNetworkError {
+    data class Code(val errorCode: Int) : PlatformNetworkError()
+    data class UntrustedCertificate(val pendingCertTrust: PendingCertTrust) : PlatformNetworkError()
+}
+
+expect fun mapPlatformNetworkError(exception: Exception): PlatformNetworkError?

--- a/core/domain/src/commonMain/kotlin/com/grappim/taigamobile/core/domain/PlatformNetworkErrorMapper.kt
+++ b/core/domain/src/commonMain/kotlin/com/grappim/taigamobile/core/domain/PlatformNetworkErrorMapper.kt
@@ -1,3 +1,0 @@
-package com.grappim.taigamobile.core.domain
-
-expect fun mapPlatformNetworkErrorCode(exception: Exception): Int?

--- a/core/domain/src/commonMain/kotlin/com/grappim/taigamobile/core/domain/PlatformNetworkErrorMapper.kt
+++ b/core/domain/src/commonMain/kotlin/com/grappim/taigamobile/core/domain/PlatformNetworkErrorMapper.kt
@@ -1,0 +1,3 @@
+package com.grappim.taigamobile.core.domain
+
+expect fun mapPlatformNetworkErrorCode(exception: Exception): Int?

--- a/core/domain/src/commonMain/kotlin/com/grappim/taigamobile/core/domain/UntrustedCertificateNetworkException.kt
+++ b/core/domain/src/commonMain/kotlin/com/grappim/taigamobile/core/domain/UntrustedCertificateNetworkException.kt
@@ -1,0 +1,3 @@
+package com.grappim.taigamobile.core.domain
+
+class UntrustedCertificateNetworkException(val pendingCertTrust: PendingCertTrust) : PlatformIOException()

--- a/core/domain/src/iosMain/kotlin/com/grappim/taigamobile/core/domain/PlatformNetworkErrorMapper.ios.kt
+++ b/core/domain/src/iosMain/kotlin/com/grappim/taigamobile/core/domain/PlatformNetworkErrorMapper.ios.kt
@@ -1,0 +1,3 @@
+package com.grappim.taigamobile.core.domain
+
+actual fun mapPlatformNetworkErrorCode(exception: Exception): Int? = null

--- a/core/domain/src/iosMain/kotlin/com/grappim/taigamobile/core/domain/PlatformNetworkErrorMapper.ios.kt
+++ b/core/domain/src/iosMain/kotlin/com/grappim/taigamobile/core/domain/PlatformNetworkErrorMapper.ios.kt
@@ -1,3 +1,3 @@
 package com.grappim.taigamobile.core.domain
 
-actual fun mapPlatformNetworkErrorCode(exception: Exception): Int? = null
+actual fun mapPlatformNetworkError(exception: Exception): PlatformNetworkError? = null

--- a/core/domain/src/jvmMain/kotlin/com/grappim/taigamobile/core/domain/CertificateHostnameMismatchException.kt
+++ b/core/domain/src/jvmMain/kotlin/com/grappim/taigamobile/core/domain/CertificateHostnameMismatchException.kt
@@ -1,0 +1,11 @@
+package com.grappim.taigamobile.core.domain
+
+import java.security.cert.CertificateException
+
+/**
+ * Thrown by the composite trust manager when the presented certificate's CN/SAN entries don't
+ * cover the host being connected to. Distinct from [UntrustedCertificateException] so
+ * [mapPlatformNetworkError] can route it to a clear "wrong host" message instead of offering a
+ * trust-on-first-use dialog that could never result in a working connection.
+ */
+class CertificateHostnameMismatchException(message: String, cause: Throwable) : CertificateException(message, cause)

--- a/core/domain/src/jvmMain/kotlin/com/grappim/taigamobile/core/domain/PlatformNetworkErrorMapper.jvm.kt
+++ b/core/domain/src/jvmMain/kotlin/com/grappim/taigamobile/core/domain/PlatformNetworkErrorMapper.jvm.kt
@@ -2,9 +2,22 @@ package com.grappim.taigamobile.core.domain
 
 import java.net.UnknownHostException
 import javax.net.ssl.SSLHandshakeException
+import javax.net.ssl.SSLPeerUnverifiedException
 
-actual fun mapPlatformNetworkErrorCode(exception: Exception): Int? = when (exception) {
-    is SSLHandshakeException -> NetworkException.ERROR_SSL_CERTIFICATE
-    is UnknownHostException -> NetworkException.ERROR_HOST_NOT_FOUND
+actual fun mapPlatformNetworkError(exception: Exception): PlatformNetworkError? = when {
+    exception is SSLHandshakeException && exception.cause is UntrustedCertificateException ->
+        PlatformNetworkError.UntrustedCertificate(
+            (exception.cause as UntrustedCertificateException).pendingCertTrust
+        )
+
+    exception is SSLHandshakeException && exception.cause is CertificateHostnameMismatchException ->
+        PlatformNetworkError.Code(NetworkException.ERROR_SSL_HOSTNAME_MISMATCH)
+
+    exception is SSLHandshakeException -> PlatformNetworkError.Code(NetworkException.ERROR_SSL_CERTIFICATE)
+
+    exception is SSLPeerUnverifiedException -> PlatformNetworkError.Code(NetworkException.ERROR_SSL_HOSTNAME_MISMATCH)
+
+    exception is UnknownHostException -> PlatformNetworkError.Code(NetworkException.ERROR_HOST_NOT_FOUND)
+
     else -> null
 }

--- a/core/domain/src/jvmMain/kotlin/com/grappim/taigamobile/core/domain/PlatformNetworkErrorMapper.jvm.kt
+++ b/core/domain/src/jvmMain/kotlin/com/grappim/taigamobile/core/domain/PlatformNetworkErrorMapper.jvm.kt
@@ -1,0 +1,10 @@
+package com.grappim.taigamobile.core.domain
+
+import java.net.UnknownHostException
+import javax.net.ssl.SSLHandshakeException
+
+actual fun mapPlatformNetworkErrorCode(exception: Exception): Int? = when (exception) {
+    is SSLHandshakeException -> NetworkException.ERROR_SSL_CERTIFICATE
+    is UnknownHostException -> NetworkException.ERROR_HOST_NOT_FOUND
+    else -> null
+}

--- a/core/domain/src/jvmMain/kotlin/com/grappim/taigamobile/core/domain/UntrustedCertificateException.kt
+++ b/core/domain/src/jvmMain/kotlin/com/grappim/taigamobile/core/domain/UntrustedCertificateException.kt
@@ -1,0 +1,12 @@
+package com.grappim.taigamobile.core.domain
+
+import java.security.cert.CertificateException
+
+/**
+ * Thrown by the composite trust manager instead of the plain [CertificateException] a default
+ * trust manager would throw, so the presented certificate's details survive the
+ * SSLHandshakeException wrapping all the way up to [mapPlatformNetworkError] and can be shown to
+ * the user instead of a generic failure.
+ */
+class UntrustedCertificateException(val pendingCertTrust: PendingCertTrust, cause: Throwable) :
+    CertificateException(cause)

--- a/core/storage/src/androidMain/kotlin/com/grappim/taigamobile/core/storage/di/StorageModule.android.kt
+++ b/core/storage/src/androidMain/kotlin/com/grappim/taigamobile/core/storage/di/StorageModule.android.kt
@@ -12,6 +12,8 @@ import com.grappim.taigamobile.core.storage.TaigaSessionStorage
 import com.grappim.taigamobile.core.storage.TaigaSessionStorageImpl
 import com.grappim.taigamobile.core.storage.auth.AuthStorage
 import com.grappim.taigamobile.core.storage.auth.AuthStorageImpl
+import com.grappim.taigamobile.core.storage.cert.TrustedCertStorage
+import com.grappim.taigamobile.core.storage.cert.TrustedCertStorageImpl
 import com.grappim.taigamobile.utils.ui.ColorMapper
 import kotlinx.serialization.json.Json
 import okio.Path.Companion.toPath
@@ -36,6 +38,10 @@ class AuthDataStoreModule {
     @Single
     fun provideSession(context: Context, @StorageJsonQualifier json: Json): FiltersStorage =
         FiltersStorageImpl(createSessionFiltersDataStore(context), json)
+
+    @Single
+    fun provideTrustedCertStorage(context: Context, @StorageJsonQualifier json: Json): TrustedCertStorage =
+        TrustedCertStorageImpl(createTrustedCertDataStore(context), json)
 }
 
 fun createSessionDataStore(context: Context): DataStore<Preferences> = PreferenceDataStoreFactory.createWithPath(
@@ -65,5 +71,11 @@ fun createAuthDataStore(context: Context): DataStore<Preferences> = PreferenceDa
     ),
     produceFile = {
         context.preferencesDataStoreFile(AUTH_DATA_STORE_FILE_NAME).absolutePath.toPath()
+    }
+)
+
+fun createTrustedCertDataStore(context: Context): DataStore<Preferences> = PreferenceDataStoreFactory.createWithPath(
+    produceFile = {
+        context.preferencesDataStoreFile(TRUSTED_CERT_DATA_STORE_FILE_NAME).absolutePath.toPath()
     }
 )

--- a/core/storage/src/commonMain/kotlin/com/grappim/taigamobile/core/storage/cert/TrustedCertStorage.kt
+++ b/core/storage/src/commonMain/kotlin/com/grappim/taigamobile/core/storage/cert/TrustedCertStorage.kt
@@ -1,0 +1,59 @@
+package com.grappim.taigamobile.core.storage.cert
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.grappim.taigamobile.core.domain.PendingCertTrust
+import com.grappim.taigamobile.core.storage.di.StorageJsonQualifier
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.json.Json
+
+interface TrustedCertStorage {
+    suspend fun isTrusted(host: String, sha256Fingerprint: String): Boolean
+    suspend fun trust(pendingCertTrust: PendingCertTrust)
+    fun getAllFlow(): Flow<List<PendingCertTrust>>
+    suspend fun untrust(host: String, sha256Fingerprint: String)
+}
+
+class TrustedCertStorageImpl(
+    private val dataStore: DataStore<Preferences>,
+    @param:StorageJsonQualifier private val json: Json
+) : TrustedCertStorage {
+
+    private val trustedEntriesFlow = dataStore.data.map { prefs ->
+        decodeEntries(prefs[TRUSTED_CERTS_KEY])
+    }
+
+    override suspend fun isTrusted(host: String, sha256Fingerprint: String): Boolean =
+        trustedEntriesFlow.first().any { it.matches(host, sha256Fingerprint) }
+
+    override suspend fun trust(pendingCertTrust: PendingCertTrust) {
+        dataStore.edit { prefs ->
+            val entries = decodeEntries(prefs[TRUSTED_CERTS_KEY])
+                .filterNot { it.matches(pendingCertTrust.host, pendingCertTrust.sha256Fingerprint) }
+            prefs[TRUSTED_CERTS_KEY] = json.encodeToString(entries + pendingCertTrust)
+        }
+    }
+
+    override fun getAllFlow(): Flow<List<PendingCertTrust>> = trustedEntriesFlow
+
+    override suspend fun untrust(host: String, sha256Fingerprint: String) {
+        dataStore.edit { prefs ->
+            val entries = decodeEntries(prefs[TRUSTED_CERTS_KEY]).filterNot { it.matches(host, sha256Fingerprint) }
+            prefs[TRUSTED_CERTS_KEY] = json.encodeToString(entries)
+        }
+    }
+
+    private fun decodeEntries(value: String?): List<PendingCertTrust> =
+        value?.takeIf { it.isNotBlank() }?.let { json.decodeFromString(it) } ?: emptyList()
+
+    private fun PendingCertTrust.matches(host: String, sha256Fingerprint: String) =
+        this.host == host && this.sha256Fingerprint == sha256Fingerprint
+
+    companion object {
+        private val TRUSTED_CERTS_KEY = stringPreferencesKey("trusted_certs")
+    }
+}

--- a/core/storage/src/commonMain/kotlin/com/grappim/taigamobile/core/storage/di/StorageModule.kt
+++ b/core/storage/src/commonMain/kotlin/com/grappim/taigamobile/core/storage/di/StorageModule.kt
@@ -14,6 +14,7 @@ import org.koin.core.annotation.Single
 internal const val SESSION_FILTERS_DATA_STORE_FILE_NAME = "taiga_session_filters_storage"
 internal const val AUTH_DATA_STORE_FILE_NAME = "auth_storage"
 internal const val TAIGA_SESSION_STORAGE = "taiga_session_storage"
+internal const val TRUSTED_CERT_DATA_STORE_FILE_NAME = "trusted_cert_storage"
 
 @Retention(AnnotationRetention.BINARY)
 @Qualifier

--- a/core/storage/src/iosMain/kotlin/com/grappim/taigamobile/core/storage/di/StorageModule.ios.kt
+++ b/core/storage/src/iosMain/kotlin/com/grappim/taigamobile/core/storage/di/StorageModule.ios.kt
@@ -10,6 +10,8 @@ import com.grappim.taigamobile.core.storage.TaigaSessionStorage
 import com.grappim.taigamobile.core.storage.TaigaSessionStorageImpl
 import com.grappim.taigamobile.core.storage.auth.AuthStorage
 import com.grappim.taigamobile.core.storage.auth.AuthStorageImpl
+import com.grappim.taigamobile.core.storage.cert.TrustedCertStorage
+import com.grappim.taigamobile.core.storage.cert.TrustedCertStorageImpl
 import com.grappim.taigamobile.utils.ui.ColorMapper
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.serialization.json.Json
@@ -37,6 +39,10 @@ class AuthDataStoreModule {
     @Single
     fun provideSession(@StorageJsonQualifier json: Json): FiltersStorage =
         FiltersStorageImpl(createSessionFiltersDataStore(), json)
+
+    @Single
+    fun provideTrustedCertStorage(@StorageJsonQualifier json: Json): TrustedCertStorage =
+        TrustedCertStorageImpl(createTrustedCertDataStore(), json)
 }
 
 fun createSessionDataStore(): DataStore<Preferences> = createDataStore(
@@ -54,6 +60,12 @@ fun createSessionFiltersDataStore(): DataStore<Preferences> = createDataStore(
 fun createAuthDataStore(): DataStore<Preferences> = createDataStore(
     producePath = {
         documentDirectory() + "/$AUTH_DATA_STORE_FILE_NAME$PREFS_EXT"
+    }
+)
+
+fun createTrustedCertDataStore(): DataStore<Preferences> = createDataStore(
+    producePath = {
+        documentDirectory() + "/$TRUSTED_CERT_DATA_STORE_FILE_NAME$PREFS_EXT"
     }
 )
 

--- a/core/storage/src/jvmMain/kotlin/com/grappim/taigamobile/core/storage/di/StorageModule.jvm.kt
+++ b/core/storage/src/jvmMain/kotlin/com/grappim/taigamobile/core/storage/di/StorageModule.jvm.kt
@@ -8,6 +8,8 @@ import com.grappim.taigamobile.core.storage.TaigaSessionStorage
 import com.grappim.taigamobile.core.storage.TaigaSessionStorageImpl
 import com.grappim.taigamobile.core.storage.auth.AuthStorage
 import com.grappim.taigamobile.core.storage.auth.AuthStorageImpl
+import com.grappim.taigamobile.core.storage.cert.TrustedCertStorage
+import com.grappim.taigamobile.core.storage.cert.TrustedCertStorageImpl
 import com.grappim.taigamobile.utils.ui.ColorMapper
 import kotlinx.serialization.json.Json
 import org.koin.core.annotation.Configuration
@@ -32,6 +34,10 @@ class AuthDataStoreModule {
     @Single
     fun provideSession(@StorageJsonQualifier json: Json): FiltersStorage =
         FiltersStorageImpl(createSessionFiltersDataStore(), json)
+
+    @Single
+    fun provideTrustedCertStorage(@StorageJsonQualifier json: Json): TrustedCertStorage =
+        TrustedCertStorageImpl(createTrustedCertDataStore(), json)
 }
 
 fun createSessionDataStore(): DataStore<Preferences> = createDataStore(
@@ -51,4 +57,10 @@ fun createSessionFiltersDataStore(): DataStore<Preferences> = createDataStore(
 
 fun createAuthDataStore(): DataStore<Preferences> = createDataStore(
     producePath = { File(System.getProperty("java.io.tmpdir"), "$AUTH_DATA_STORE_FILE_NAME$PREFS_EXT").absolutePath }
+)
+
+fun createTrustedCertDataStore(): DataStore<Preferences> = createDataStore(
+    producePath = {
+        File(System.getProperty("java.io.tmpdir"), "$TRUSTED_CERT_DATA_STORE_FILE_NAME$PREFS_EXT").absolutePath
+    }
 )

--- a/core/storage/src/jvmTest/kotlin/com/grappim/taigamobile/core/storage/cert/TrustedCertStorageImplTest.kt
+++ b/core/storage/src/jvmTest/kotlin/com/grappim/taigamobile/core/storage/cert/TrustedCertStorageImplTest.kt
@@ -1,0 +1,130 @@
+package com.grappim.taigamobile.core.storage.cert
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import com.grappim.taigamobile.core.domain.PendingCertTrust
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import okio.Path.Companion.toPath
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TrustedCertStorageImplTest {
+
+    private fun createSut(): TrustedCertStorageImpl {
+        val file = File.createTempFile("trusted_cert_storage_test", ".preferences_pb")
+        file.deleteOnExit()
+        val dataStore = PreferenceDataStoreFactory.createWithPath(
+            produceFile = { file.absolutePath.toPath() }
+        )
+        return TrustedCertStorageImpl(dataStore, Json { ignoreUnknownKeys = true })
+    }
+
+    private fun makeCertTrust(
+        host: String,
+        sha256Fingerprint: String,
+        subject: String = "CN=$host",
+        issuer: String = "CN=Test CA"
+    ) = PendingCertTrust(
+        host = host,
+        subject = subject,
+        issuer = issuer,
+        notBefore = "2026-01-01",
+        notAfter = "2027-01-01",
+        sha256Fingerprint = sha256Fingerprint
+    )
+
+    @Test
+    fun `isTrusted returns false for a host and fingerprint that were never trusted`() = runTest {
+        val sut = createSut()
+
+        assertFalse(sut.isTrusted("taiga.example.com", "AA:BB:CC"))
+    }
+
+    @Test
+    fun `trust then isTrusted returns true for the same host and fingerprint`() = runTest {
+        val sut = createSut()
+
+        sut.trust(makeCertTrust("taiga.example.com", "AA:BB:CC"))
+
+        assertTrue(sut.isTrusted("taiga.example.com", "AA:BB:CC"))
+    }
+
+    @Test
+    fun `trust for one host does not grant trust for a different host with the same fingerprint`() = runTest {
+        val sut = createSut()
+
+        sut.trust(makeCertTrust("taiga.example.com", "AA:BB:CC"))
+
+        assertFalse(sut.isTrusted("other.example.com", "AA:BB:CC"))
+    }
+
+    @Test
+    fun `trusting multiple host-fingerprint pairs keeps them independently trusted`() = runTest {
+        val sut = createSut()
+
+        sut.trust(makeCertTrust("taiga.example.com", "AA:BB:CC"))
+        sut.trust(makeCertTrust("other.example.com", "DD:EE:FF"))
+
+        assertTrue(sut.isTrusted("taiga.example.com", "AA:BB:CC"))
+        assertTrue(sut.isTrusted("other.example.com", "DD:EE:FF"))
+        assertFalse(sut.isTrusted("taiga.example.com", "DD:EE:FF"))
+    }
+
+    @Test
+    fun `trust for the same host-fingerprint pair again replaces the stored entry, not duplicates it`() = runTest {
+        val sut = createSut()
+
+        sut.trust(makeCertTrust("taiga.example.com", "AA:BB:CC", subject = "CN=old"))
+        sut.trust(makeCertTrust("taiga.example.com", "AA:BB:CC", subject = "CN=new"))
+
+        val entries = sut.getAllFlow().first()
+        assertEquals(1, entries.size)
+        assertEquals("CN=new", entries.single().subject)
+    }
+
+    @Test
+    fun `getAllFlow is empty when nothing has been trusted`() = runTest {
+        val sut = createSut()
+
+        assertEquals(emptyList(), sut.getAllFlow().first())
+    }
+
+    @Test
+    fun `getAllFlow reflects every trusted entry with its full cert info`() = runTest {
+        val sut = createSut()
+
+        val first = makeCertTrust("taiga.example.com", "AA:BB:CC")
+        val second = makeCertTrust("other.example.com", "DD:EE:FF")
+        sut.trust(first)
+        sut.trust(second)
+
+        val entries = sut.getAllFlow().first()
+        assertEquals(setOf(first, second), entries.toSet())
+    }
+
+    @Test
+    fun `untrust removes only the matching host-fingerprint pair`() = runTest {
+        val sut = createSut()
+        sut.trust(makeCertTrust("taiga.example.com", "AA:BB:CC"))
+        sut.trust(makeCertTrust("other.example.com", "DD:EE:FF"))
+
+        sut.untrust("taiga.example.com", "AA:BB:CC")
+
+        assertFalse(sut.isTrusted("taiga.example.com", "AA:BB:CC"))
+        assertTrue(sut.isTrusted("other.example.com", "DD:EE:FF"))
+    }
+
+    @Test
+    fun `untrust for an unknown pair is a no-op`() = runTest {
+        val sut = createSut()
+        sut.trust(makeCertTrust("taiga.example.com", "AA:BB:CC"))
+
+        sut.untrust("never.example.com", "00:00:00")
+
+        assertTrue(sut.isTrusted("taiga.example.com", "AA:BB:CC"))
+    }
+}

--- a/docs/private-cert-trust/plan.md
+++ b/docs/private-cert-trust/plan.md
@@ -1,0 +1,320 @@
+# Private CA / Self-Signed Certificate Trust — Implementation Plan
+
+See `research.md` in this folder for the survey this plan is based on (Nextcloud, Jellyfin,
+Syncthing, Home Assistant).
+
+## Progress
+
+- [x] **Phase 1 — Storage**
+  - [x] `TrustedCertStorage` interface + `DataStore`-backed impl (`core/storage/.../cert/TrustedCertStorage.kt`)
+  - [x] Per-platform DataStore provider wiring in `StorageModule.android.kt` / `.jvm.kt` / `.ios.kt`
+  - [x] `FakeTrustedCertStorage` in `testing/`
+  - [x] Unit tests (`core/storage/src/jvmTest/.../cert/TrustedCertStorageImplTest.kt`) — real `DataStore` round-trip, covers host-scoping specifically
+- [x] **Phase 2 — Trust manager + OkHttp engine wiring**
+  - [x] Composite `X509TrustManager` (Android/JVM), checks `TrustedCertStorage` before falling back to the platform default
+  - [x] expect/actual platform `HttpClientEngine` provider hook (`core/api`)
+  - [x] `KmpNetworkModule.kt` updated to use the new engine hook instead of bare `HttpClient { }`
+  - [x] Unit tests (`core/api/src/jvmTest/.../CompositeTrustManagerTest.kt`) — pin hit/miss, host-scoping, cert-scoping, expiry-on-pin-hit, null-host fallback
+- [x] **Phase 3 — Exception plumbing**
+  - [x] `PendingCertTrust` portable model (`core/domain`)
+  - [x] Chain-carrying `CertificateException` subtype (`UntrustedCertificateException`, Android/JVM-shared, lives in `core/domain` not `core/api` — see note below)
+  - [x] `NetworkErrorMapper` detects and passes it through distinctly instead of collapsing to a generic code
+  - [x] Unit tests (`core/api/src/jvmTest/.../CompositeTrustManagerTest.kt` + `.../errors/NetworkErrorMapperJvmTest.kt`) — wrapping, unwrapping, and the plain-SSL-failure-still-falls-back-to-generic-code case
+- [x] **Phase 4 — Login UI**
+  - [x] `LoginViewModel` state + retry-on-accept flow (shared `handleFailure` helper used by all three failure sites: password/LDAP login, GitHub client-id fetch, GitHub code exchange)
+  - [x] `LoginScreen` — second `ConfirmActionDialog` instance for cert trust (reused, no new uikit component)
+  - [x] New strings (`cert_trust_dialog_title`, `cert_trust_dialog_description`)
+  - [x] Unit tests (`LoginViewModelTest.kt`) — dialog shown on failure, dismiss clears without retry/trust, confirm persists the pin and retries
+- [x] **Phase 5 — Tests + manual QA**
+  - [x] Unit tests for `TrustedCertStorage`, composite trust manager, `NetworkErrorMapper`, `LoginViewModel` — all done incrementally in Phases 1–4
+  - [x] Manual repro against a local self-signed instance (see `server-setup.md`) — done against a throwaway nginx TLS proxy in front of the local docker-compose Taiga instance. Confirmed: dialog shows correct issuer/subject/validity/fingerprint, dismiss doesn't persist anything, accept pins and retries, pin survives app restart.
+  - [x] **QA finding (not a bug, confirmed by design):** logging out, logging into a different server, then logging back into the previously-trusted untrusted-cert host does **not** re-show the dialog. This is correct — the pin is keyed by `(host, fingerprint)` in `TrustedCertStorage`, independent of login session state (`AuthStorage` is untouched by this feature). Re-prompting on every login would defeat the purpose of TOFU pinning and would train users to reflexively accept dialogs. The dialog correctly reappears only if the host's fingerprint actually changes (rotation or MITM swap attempt) — see `server-setup.md` step 6 for the test that proves this.
+- [x] **Phase 6 — Settings UI to view/revoke trusted certs**
+  - Promoted from "Out of Scope" below, triggered by the Phase 5 QA finding above: there was no way for a user to un-pin a host short of clearing app data. Added a "Trusted Certificates" screen under Settings listing pinned entries with a revoke action per row.
+  - **Scope decision (revised):** initially built as host + fingerprint only (matching what was persisted at the time), then explicitly revisited — since this feature hasn't shipped yet, there was no migration cost to widening the storage shape now rather than living with a fingerprint-only revoke screen long-term. Went with the full `PendingCertTrust` (host, subject, issuer, notBefore, notAfter, sha256Fingerprint) instead, so the revoke screen can show *why* a cert was trusted (issuer, expiry), not just an opaque hash.
+  - `PendingCertTrust` (`core/domain`) is now `@Serializable` and reused directly as the persisted entry type — no separate storage-layer model. `TrustedCertStorage` (`core/storage/.../cert/TrustedCertStorage.kt`) signature changed: `trust(host, fingerprint)` → `trust(pendingCertTrust: PendingCertTrust)`, added `getAllFlow(): Flow<List<PendingCertTrust>>` and `suspend fun untrust(host, sha256Fingerprint)`. `isTrusted(host, fingerprint)` unchanged. Storage format changed from a `stringSetPreferencesKey` of delimited `"host|fingerprint"` strings to a single `stringPreferencesKey` holding a JSON-encoded `List<PendingCertTrust>` (via the existing `@StorageJsonQualifier` `Json` instance, same convention `FiltersStorageImpl` already uses) — trusting an already-pinned `(host, fingerprint)` again replaces the stored entry rather than duplicating it. `FakeTrustedCertStorage` (`testing/`) and `LoginViewModel.onConfirmCertTrust()` (now passes the whole `pendingCertTrust` instead of just two of its fields) updated to match.
+  - New screen: `feature/settings/ui/.../trustedcerts/` (`TrustedCertificatesScreen.kt`, `TrustedCertificatesState.kt`, `TrustedCertificatesViewModel.kt`, `TrustedCertificatesNavDestination.kt`) — modeled on the existing `attributes/tags/TagsScreen*` list-with-delete pattern (`LazyColumn` + `ListItem` rows + trailing delete `IconButton` + `ConfirmActionDialog` confirm-before-revoke), but simpler: no loading/error state needed since reads/writes are local `DataStore` calls, not network. `TrustedCertificatesViewModel` collects `getAllFlow()` directly into state, so revoking an entry updates the list reactively with no manual list-filtering. Each row shows host (headline) + issuer, valid-until date, and fingerprint (supporting content). Empty state reuses uikit's existing `EmptyStateWidget` with its default message.
+  - Wired into `SettingsScreen.kt` (new `ListItem` + `goToTrustedCertificatesScreen` callback, unconditional — not gated behind `canSeeAttributes` since TLS trust is device-level, not project-permission-based) and `composeApp/.../nav/SettingsNavGraph.kt` (new `composable<TrustedCertificatesNavDestination>` block).
+  - New strings: `settings_trusted_certificates`, `trusted_cert_issuer`, `trusted_cert_valid_until`, `trusted_cert_fingerprint`, `revoke_cert_title`, `revoke_cert_text`.
+  - Unit tests: `core/storage/src/jvmTest/.../cert/TrustedCertStorageImplTest.kt` (real-DataStore `trust`/`getAllFlow`/`untrust` round-trip, including re-trusting an existing pin replaces rather than duplicates) + `feature/settings/ui/src/commonTest/.../trustedcerts/TrustedCertificatesViewModelTest.kt` (init population, revoke-click/confirm/dismiss flow) + `CompositeTrustManagerTest.kt` updated for the new `trust()` signature (via a test-local `FakeTrustedCertStorage.trust(host, fingerprint)` convenience overload, since those tests only care about the pin, not the full cert metadata) — all passing.
+- [x] **Phase 7 — Hostname/certificate mismatch handling**
+  - **Bug found via manual QA (2026-07-24):** a self-signed cert issued for `192.168.0.241` was reachable at `192.168.0.248` (wrong IP typed / server moved between test runs). Two related gaps surfaced:
+    1. Connecting to the wrong host with an otherwise-fine (or already-pinned) cert threw `SSLPeerUnverifiedException` — a *different* exception than the `SSLHandshakeException`/`CertificateException` path `NetworkErrorMapper` already handled — so it fell all the way through to the generic `ERROR_NETWORK_IO` fallback instead of any SSL-specific message.
+    2. Worse: connecting to `.248` with the *untrusted* `.241` cert still triggered the untrusted-cert TOFU dialog (chain-trust validation runs before hostname verification, and our trust manager only cares about chain trust). Accepting it persisted a pin for `(192.168.0.248, that fingerprint)` — a pin that can never actually let a connection succeed, since hostname verification is a separate OkHttp step untouched by our trust manager and will keep rejecting the SAN/CN mismatch regardless of the pin.
+  - Fix, part 1 — generic mismatch message: `NetworkException.ERROR_SSL_HOSTNAME_MISMATCH` (new code) + `error_ssl_hostname_mismatch` string. `mapPlatformNetworkError` (both platform actuals) now maps `SSLPeerUnverifiedException` to it directly.
+  - Fix, part 2 — stop offering TOFU for a cert that can never work: `CompositeTrustManager.checkServerTrusted` (`core/api/{android,jvm}Main`) now checks whether the presented leaf cert's SAN entries (DNS name type 2 / IP address type 7, falling back to the subject CN if no SANs are present) actually cover the connecting host *before* wrapping the failure as an offer to trust. On mismatch it throws a new `CertificateHostnameMismatchException` (`core/domain/{android,jvm}Main`, same placement/reasoning as `UntrustedCertificateException`) instead of `UntrustedCertificateException` — no dialog shown, since pinning would be pointless. `mapPlatformNetworkError` routes this to the same `ERROR_SSL_HOSTNAME_MISMATCH` code as part 1, so both "chain untrusted and wrong host" and "chain trusted but wrong host" show the identical clear message instead of a confusing trust prompt.
+  - This check only runs on the *offer-TOFU* path (unpinned cert, default trust manager rejected it) — a hostname match is **not** re-verified on every pin hit, since that would re-litigate a decision the user already made for an already-pinned exact `(host, fingerprint)`.
+  - `FakeX509Certificate` (`core/api/jvmTest`) gained a `commonName` (default `"taiga.example.com"`, chosen to keep every pre-existing test passing unmodified) and `subjectAlternativeNames` constructor param to make this testable.
+  - Unit tests: `CompositeTrustManagerTest.kt` (CN mismatch rejected, SAN-IP match still offers TOFU, SAN-IP mismatch rejected — reproducing the exact `.241`/`.248` scenario) + `NetworkErrorMapperJvmTest.kt` (`SSLPeerUnverifiedException` and `CertificateHostnameMismatchException` both → `ERROR_SSL_HOSTNAME_MISMATCH`) — all passing.
+
+## Goal
+
+Let a user connect to a self-hosted Taiga instance whose TLS certificate isn't trusted by
+Android's default CA store (self-signed, or issued by a private CA) — currently this fails with
+no way to proceed at all, as reported in
+[#322](https://github.com/Grigoriym/TaigaMobileNova/issues/322).
+
+**Scope: Android only.** The mechanics below (OkHttp engine, `X509TrustManager`) are also valid on
+JVM Desktop since it shares the OkHttp engine, so the storage/trust-manager layer will work there
+for free — but the Login UI flow described here is only being built for Android right now. iOS
+(Darwin engine) is untouched.
+
+## Decision: pattern C (trust-on-first-use per-host pinning), not B
+
+Rejected app-wide `network_security_config.xml` trusting user CAs (pattern B, used by Jellyfin and
+Home Assistant) because both surveyed implementations share the same weakness: trust is global to
+the device and every domain the app talks to, with zero user-facing visibility into *which*
+certificate was actually accepted. Building pattern C instead, modeled on Nextcloud's approach
+(the only surveyed app that does this for real), but fixing two flaws found in their
+implementation:
+
+1. **Pin `(host, fingerprint)`, not fingerprint alone.** Nextcloud's `isKnownServer()` checks the
+   certificate only — once accepted for any host, that exact cert is silently trusted for *any*
+   other host that presents it. We scope the stored pin to the host it was accepted for.
+2. **Still validate expiry on every connection**, even for a previously-pinned cert. Nextcloud
+   skips `checkValidity()` entirely once a cert is in the known-servers store, so an
+   expired-but-previously-accepted cert is trusted forever with no re-check.
+
+Also explicitly **not** copying Syncthing's disabled hostname verification (only safe there
+because its target is hardcoded to loopback) or Nextcloud's plaintext-file `KeyStore` with a
+hardcoded password (`"password"`) — using `DataStore<Preferences>` instead, consistent with how
+`AuthStorage` already persists auth tokens in this codebase.
+
+## Flow
+
+1. User enters a server URL, taps Continue/Login.
+2. `AuthRepository` request fails at the TLS handshake because the cert isn't in the system trust
+   store and isn't yet pinned for this host.
+3. The composite trust manager (installed in the OkHttp engine) has already seen the full
+   presented chain during `checkServerTrusted` — on rejection it throws a `CertificateException`
+   subtype carrying the chain details (subject, issuer, validity, SHA-256 fingerprint), not just a
+   bare failure.
+4. This propagates up through Ktor as an `SSLHandshakeException` wrapping that exception.
+   `NetworkErrorMapper` (via the existing `mapPlatformNetworkErrorCode` platform hook) recognizes
+   it specifically and it reaches `LoginViewModel` as a distinct, inspectable failure — not
+   collapsed into the generic `ERROR_SSL_CERTIFICATE` message we already ship.
+5. `LoginViewModel` shows a confirm dialog (reusing uikit's existing `ConfirmActionDialog` — same
+   component already used for the "unencrypted connection" warning) with the cert's issuer,
+   subject, validity dates, and SHA-256 fingerprint formatted into the description text.
+6. **Accept** → `TrustedCertStorage.trust(host, fingerprint)` → retry the original login request
+   (now the trust manager's pin check on step 3 succeeds).
+   **Reject** → dismiss, login fails as it does today.
+7. Any *later* request to a host with a rotated/different cert (pin no longer matches) fails the
+   same way it does today (generic `ERROR_SSL_CERTIFICATE` message) — no re-prompt outside the
+   login flow. See Out of Scope.
+
+## Architecture
+
+### `core/storage` — `TrustedCertStorage`
+
+New interface + `DataStore<Preferences>`-backed impl, same shape as `AuthStorage`:
+
+```kotlin
+// core/storage/src/commonMain/.../cert/TrustedCertStorage.kt
+interface TrustedCertStorage {
+    suspend fun isTrusted(host: String, sha256Fingerprint: String): Boolean
+    suspend fun trust(host: String, sha256Fingerprint: String)
+}
+```
+
+Stored as a `Set<String>` of `"$host|$sha256Fingerprint"` entries in its own DataStore file
+(`trusted_certs`), following the exact pattern `PlatformStorageModule`/`provideAuthStorage` already
+use per platform in `StorageModule.android.kt` / `.jvm.kt` / `.ios.kt`. **Done** — see
+`core/storage/src/commonMain/.../cert/TrustedCertStorage.kt`.
+
+### `core/api` — composite trust manager + OkHttp engine wiring (done)
+
+Built as planned below, with one scope decision made during implementation: **Phase 2 does not yet
+change the error surfaced for an unpinned/rejected cert.** `CompositeTrustManager.checkServerTrusted`
+falls back to the real default `X509TrustManager` and lets whatever it throws propagate completely
+unchanged — same `CertificateException` → `SSLHandshakeException` → generic `ERROR_SSL_CERTIFICATE`
+path as before this feature existed. Phase 2 only adds the *capability* to succeed on a pinned
+`(host, fingerprint)`; it deliberately doesn't touch the failure path yet. That's what Phase 3 is for
+(see below — the chain-carrying exception is still not built).
+
+- `core/api/src/androidMain/.../CompositeTrustManager.kt` (+ identical copy in `jvmMain`, same
+  reasoning as `PlatformNetworkErrorMapper`'s Android/JVM duplication — both share the OkHttp
+  engine): wraps a real default `X509TrustManager` (`TrustManagerFactory` with a `null` `KeyStore`,
+  i.e. the system trust store). `checkServerTrusted` extracts the host from the `SSLSocket`/
+  `SSLEngine` overload (`handshakeSession.peerHost` / `engine.peerHost`), checks
+  `TrustedCertStorage.isTrusted(host, sha256Fingerprint(leaf))` — **still calling
+  `leaf.checkValidity()` even on a pin hit**, fixing the flaw flagged in Nextcloud's implementation
+  — and only falls back to the default manager if unpinned. Hostname verification is untouched
+  (OkHttp's default), not disabled à la Syncthing.
+- `core/api/src/commonMain/.../PlatformHttpClientEngine.kt`: `expect fun
+  createPlatformHttpClientEngine(trustedCertStorage: TrustedCertStorage): HttpClientEngine`. Android/
+  JVM actual builds an `SSLContext` around the composite trust manager and passes it to
+  `OkHttp.create { config { sslSocketFactory(...) } } }`. iOS actual is `Darwin.create()`, ignoring
+  the parameter — unchanged behavior, matches the "Android only for now" scope.
+- `KmpNetworkModule.kt`'s two `@Single HttpClient` providers now take `TrustedCertStorage` as an
+  injected parameter and construct via `HttpClient(createPlatformHttpClientEngine(trustedCertStorage))
+  { ... }` instead of the old engine-agnostic `HttpClient { ... }`.
+
+### `core/domain` — portable cert-info model + exception (done)
+
+```kotlin
+// core/domain/src/commonMain/.../PendingCertTrust.kt
+data class PendingCertTrust(
+    val host: String,
+    val subject: String,
+    val issuer: String,
+    val notBefore: String,
+    val notAfter: String,
+    val sha256Fingerprint: String
+)
+```
+
+Kept fully portable (no `java.security.cert.X509Certificate`) so `LoginViewModel`/UI code in
+commonMain can consume it directly.
+
+**Module-placement correction made during implementation:** the original sketch assumed the
+chain-carrying `CertificateException` subtype would live in `core/api` (next to
+`CompositeTrustManager`). That's backwards — `core/api` depends on `core/domain`, not the other way
+around, and the Phase 3 unwrapping logic (`mapPlatformNetworkError`, an expect/actual) has to live
+in `core/domain` too since that's where `PlatformIOException`'s existing platform-detection
+machinery already lives. So `UntrustedCertificateException` (Android/JVM-shared, `CertificateException`
+subtype, carries a `PendingCertTrust`) was placed in `core/domain/src/androidMain` +
+`core/domain/src/jvmMain` instead — `core/api`'s `CompositeTrustManager` just imports it from there,
+which is the correct dependency direction.
+
+Two distinct exception types ended up necessary, at two different layers:
+
+- **`UntrustedCertificateException`** (`core/domain`, Android/JVM-only, `CertificateException`
+  subtype) — internal plumbing. Thrown by `CompositeTrustManager` to satisfy JSSE's contract; never
+  leaves the Android/JVM boundary except being unwrapped by the platform actual below.
+- **`UntrustedCertificateNetworkException`** (`core/domain`, commonMain, `PlatformIOException`
+  subtype, carries a `PendingCertTrust`) — the portable type that actually propagates up through
+  Ktor → `ErrorMappingPlugin` → `AuthRepository` → `LoginViewModel`, where Phase 4 will catch it
+  specifically.
+
+`mapPlatformNetworkErrorCode(exception): Int?` (the existing expect/actual hook) was widened into
+`mapPlatformNetworkError(exception): PlatformNetworkError?`, where `PlatformNetworkError` is a new
+commonMain sealed class (`Code(errorCode: Int)` | `UntrustedCertificate(pendingCertTrust:
+PendingCertTrust)`). The Android/JVM actual checks whether an `SSLHandshakeException`'s `cause` is
+an `UntrustedCertificateException` first (→ `UntrustedCertificate`), otherwise falls back to the
+same `SSLHandshakeException`/`UnknownHostException` → `Code(...)` mapping as before. iOS actual
+unchanged, still always `null`.
+
+`NetworkErrorMapper.mapToNetworkException` now branches on `PlatformNetworkError.UntrustedCertificate`
+→ constructs `UntrustedCertificateNetworkException`, vs. `PlatformNetworkError.Code` → constructs
+`NetworkException(errorCode)` as before.
+
+`NativeText.getErrorMessage` gained a case for `UntrustedCertificateNetworkException` → the existing
+`error_ssl_certificate` string, as the fallback for any caller that doesn't specifically intercept
+it (i.e. everything except the Phase 4 login flow) — matches the "Out of Scope" decision that
+non-login requests hitting an untrusted cert keep showing the generic message.
+
+### `core/api` — composite trust manager + OkHttp engine wiring (done)
+
+Built as planned above (see the Phase 2 note higher up in this doc) — `CompositeTrustManager` was
+revisited in Phase 3 to add the try/catch around `defaultTrustManager.checkServerTrusted`: on
+failure, if `host != null` it now throws `UntrustedCertificateException(pendingCertTrust, cause)`
+instead of letting the bare `CertificateException` through; if `host == null` (no way to offer TOFU)
+the original exception still propagates unchanged. `pendingCertTrust(...)` extracts subject/issuer
+via `certificate.subjectX500Principal.name`/`issuerX500Principal.name` and formats validity dates as
+`yyyy-MM-dd`.
+
+### `feature/login/ui` — the dialog + retry (done)
+
+**Scope decision made during implementation:** the original sketch only mentioned wiring this into
+the main password/LDAP `login()` path. In practice `LoginViewModel` has three separate places that
+call the auth repo and handle failure identically (`login(authData)`, `startGithubOAuth()`,
+`authWithGithub(code)`) — GitHub login goes through the same `HttpClient` and can hit the exact same
+untrusted-cert failure. Leaving two of the three paths showing a raw fallback message while only one
+got the dialog would've been an inconsistent, confusing UX for no real savings, so all three route
+through one shared helper instead:
+
+```kotlin
+private fun handleFailure(error: Throwable, logMessage: String, retry: () -> Unit) {
+    logcat(throwable = error) { logMessage }
+    isLoading(false)
+    if (error is UntrustedCertificateNetworkException) {
+        pendingRetry = retry
+        _state.update { it.copy(pendingCertTrust = error.pendingCertTrust, isCertTrustDialogVisible = true) }
+    } else {
+        _state.update { it.copy(error = getErrorMessage(error)) }
+    }
+}
+```
+
+Each call site passes its own retry lambda (`{ login(authData) }` / `{ startGithubOAuth() }` /
+`{ authWithGithub(code) }`) and its original log tag (`"Login error"` / `"GitHub OAuth error"` /
+`"GitHub auth error"`), so the existing per-path log distinction wasn't lost. `pendingRetry` is a
+plain `private var` on the ViewModel (not part of `LoginState`, since it's a function, not display
+state) — `onConfirmCertTrust()` persists the pin via `TrustedCertStorage.trust(...)`, clears the
+dialog state, then invokes it; `onDismissCertTrust()` just clears state without touching storage or
+retrying.
+
+`LoginScreen.kt` reuses `ConfirmActionDialog` (already used for the insecure-connection warning) —
+no new uikit component needed. `description` is built via
+`stringResource(RString.cert_trust_dialog_description, host, issuer, subject, notBefore, notAfter,
+sha256Fingerprint)`, guarded by `state.pendingCertTrust?.let { ... }` since the dialog param is
+nullable and only ever populated together with `isCertTrustDialogVisible = true`.
+
+One dependency fix needed along the way: `feature/login/ui` didn't have a direct `core.domain`
+dependency (only transitively through `core.api`'s `implementation`, which Gradle doesn't expose
+downstream) — added `implementation(projects.core.domain)` to its `build.gradle.kts` so
+`PendingCertTrust`/`UntrustedCertificateNetworkException` resolve.
+
+## Files Created (Phases 1–3)
+
+| File | Description |
+|------|--------------|
+| `core/storage/src/commonMain/.../cert/TrustedCertStorage.kt` | Interface + `DataStore`-backed impl |
+| `core/storage/src/{android,jvm,ios}Main/.../di/StorageModule.*.kt` | Per-platform DataStore provider additions, mirroring `provideAuthStorage` |
+| `core/storage/src/jvmTest/.../cert/TrustedCertStorageImplTest.kt` | Real-`DataStore` round-trip tests |
+| `testing/.../storage/FakeTrustedCertStorage.kt` | Fake for ViewModel tests (Phase 4) |
+| `core/domain/src/commonMain/.../PendingCertTrust.kt` | Portable cert-info model |
+| `core/domain/src/commonMain/.../UntrustedCertificateNetworkException.kt` | Portable, propagates up through Ktor to the ViewModel |
+| `core/domain/src/{android,jvm}Main/.../UntrustedCertificateException.kt` | Internal, `CertificateException` subtype for the JSSE contract |
+| `core/domain/src/commonMain/.../PlatformNetworkErrorMapper.kt` | Widened to `PlatformNetworkError` sealed class + `mapPlatformNetworkError` (was `mapPlatformNetworkErrorCode: Int?`) |
+| `core/api/src/commonMain/.../PlatformHttpClientEngine.kt` (+ `android`/`jvm`/`ios` actuals) | expect/actual engine provider hook |
+| `core/api/src/{android,jvm}Main/.../CompositeTrustManager.kt` | Composite `X509TrustManager` |
+| `core/api/src/jvmTest/.../CompositeTrustManagerTest.kt` + `FakeX509Certificate.kt` + `FakeX509TrustManager.kt` | Unit tests + hand-written doubles |
+| `core/api/src/jvmTest/.../errors/NetworkErrorMapperJvmTest.kt` | JVM-only tests (`SSLHandshakeException`/`UnknownHostException` aren't available to `commonTest`) |
+
+## Files Modified (Phases 1–3)
+
+| File | Change |
+|------|--------|
+| `core/api/.../errors/NetworkErrorMapper.kt` | Branches on `PlatformNetworkError` instead of a bare `Int?` |
+| `core/api/.../KmpNetworkModule.kt` | Both `HttpClient` providers take `TrustedCertStorage` and build via `createPlatformHttpClientEngine(...)` |
+| `utils/ui/.../NativeText.kt` | `getErrorMessage` gained an `UntrustedCertificateNetworkException` → `error_ssl_certificate` fallback case |
+
+## Files Still To Create/Modify (Phase 4)
+
+| File | Change |
+|------|--------|
+| `feature/login/ui/.../LoginViewModel.kt` | New state + retry-on-accept flow |
+| `feature/login/ui/.../LoginScreen.kt` | Second `ConfirmActionDialog` instance for cert trust |
+| `strings.xml` | New dialog title/description strings |
+
+## What Stays the Same
+
+- `ERROR_SSL_CERTIFICATE` / `error_ssl_certificate` message already shipped — stays as the
+  fallback shown for any request that hits an untrusted cert outside the login flow (see Out of
+  Scope).
+- `AuthHeaderPlugin`, `TokenRefreshPlugin`, `HostSelectionPlugin` — untouched.
+- Existing cleartext-HTTP warning dialog/flow — untouched, unrelated code path.
+
+## Out of Scope (for now)
+
+- Re-prompting mid-session if a previously-pinned cert rotates on a background request — falls
+  back to the existing generic error message, pushing the user to re-login to re-trust.
+- iOS (Darwin engine) support.
+- ~~A UI to view/revoke previously-trusted certs (e.g. in Settings).~~ — promoted to Phase 6 above
+  after manual QA (2026-07-24) raised the question of un-pinning a host without clearing app data.
+- Certificate pinning to a fixed set of known-good CAs (unrelated feature, not what's being asked
+  for here).
+- ~~Showing subject/issuer/validity dates in the Phase 6 revoke screen.~~ — done; revisited the
+  scope decision before shipping and widened storage to the full `PendingCertTrust` (see Phase 6
+  note above) rather than leaving a fingerprint-only screen as permanent scope.
+
+## Open Questions
+
+- ~~Exact return type change needed on `mapPlatformNetworkErrorCode`...~~ — resolved in Phase 3:
+  widened to `PlatformNetworkError` sealed class, see Architecture section above.
+- ~~Whether `TrustedCertStorage` should live under `core/storage/.../cert/` or alongside
+  `core/storage/.../auth/`~~ — resolved in Phase 1: went with `.../cert/`, kept as its own file
+  rather than folded into `AuthStorage`, since the two are conceptually separate (login credentials
+  vs. TLS trust decisions) even though both persist via `DataStore`.

--- a/docs/private-cert-trust/research.md
+++ b/docs/private-cert-trust/research.md
@@ -1,0 +1,240 @@
+# Self-Signed / Private-CA Certificate Trust — Research
+
+## Background
+
+Reported in [#322](https://github.com/Grigoriym/TaigaMobileNova/issues/322): a self-hosted Taiga
+instance using a cert issued by a private CA fails to connect on Android with an opaque
+"Connection error". Root cause: Android excludes user-installed CAs from app trust by default
+(since API 24) unless the app opts in via `network_security_config.xml`, and this project's
+`ErrorMappingPlugin`/`NetworkErrorMapper` collapsed `SSLHandshakeException` into the same generic
+bucket as any other I/O failure (fixed separately — see `ERROR_SSL_CERTIFICATE` in
+`NetworkException.kt`).
+
+This doc is a scratchpad of findings on how other self-hosted-client Android apps handle
+connecting to a server with an untrusted certificate, gathered before deciding what (if anything)
+TaigaMobileNova should build. **No decision has been made yet** — this is investigation only.
+
+Three known patterns going in:
+
+- **(A) Do nothing** — tell users to get a properly-trusted cert (Let's Encrypt, reverse proxy).
+- **(B) `network_security_config.xml`** trusting user-installed CAs app-wide.
+- **(C) Trust-on-first-use (TOFU) per-server certificate pinning** — show the user the cert
+  fingerprint on first connect, let them accept it, pin that exact cert for that exact host going
+  forward, independent of the system/user CA store.
+
+---
+
+## nextcloud-android
+
+**Pattern used:** hybrid of B + C, not just one of the three.
+
+### Layer 1 — Pattern B (`network_security_config.xml`)
+
+`app/src/main/res/xml/network_security_config.xml`:
+
+- Global base-config, no domain scoping, applies in release builds (no `<debug-overrides>`)
+- Trusts `src="system"` and `src="user"` CAs, plus `cleartextTrafficPermitted="true"`
+- Only governs components using the platform default `SSLContext`/trust manager (WebView's normal
+  TLS path, any library that doesn't install its own `SSLSocketFactory`)
+
+### Layer 2 — Pattern C (TOFU pinning — the actual mechanism for the real API client)
+
+Classes live in the `com.github.nextcloud:android-library` dependency (not in the app repo's
+source tree — found by decompiling the AAR from the Gradle cache): `NetworkUtils`,
+`AdvancedX509TrustManager`, `AdvancedSslSocketFactory`.
+
+- `NextcloudClient$Companion.getOkHttpClient` builds an `AdvancedX509TrustManager` backed by a
+  "known servers" `KeyStore` and installs it via
+  `OkHttpClient.Builder.sslSocketFactory(sslSocketFactory, trustManager)` — the modern OkHttp
+  REST client uses this custom trust manager, not just legacy code.
+- Same trust manager is also wired into the legacy Apache-HttpClient path
+  (`OwnCloudClientFactory.createOwnCloudClient` → `NetworkUtils.registerAdvancedSslContext`).
+- Dialog: `SslUntrustedCertDialog.kt` (app repo) + `X509CertificateViewAdapter.java` — shown on
+  both native TLS failures and WebView `onReceivedSslError` (`NextcloudWebViewClient.kt`).
+
+**Trust-decision logic** (`AdvancedX509TrustManager.checkServerTrusted`, decompiled):
+
+1. If the presented cert is already in the known-servers store → trust immediately, **no further
+   checks at all** (skips validity/expiry check and skips standard chain validation entirely).
+2. Otherwise, falls through to `TrustManagerFactory.init(null)` (system default CAs only — not
+   user-installed CAs at this layer) + explicit `checkValidity()`; failures are bundled into a
+   `CertificateCombinedException` and surfaced to the dialog.
+
+**Dialog content on accept/reject:**
+
+- Shows: Subject CN/O/OU/C/ST/L, Issuer CN/O/OU/C/ST/L, validity dates, fingerprints (SHA-256,
+  SHA-1, MD5), signature algorithm.
+- Accept → `NetworkUtils.addCertToKnownServersStore(cert, context)`.
+- Reject → `sslErrorHandler.cancel()` / dialog cancel, connection aborted.
+
+**Persistence:**
+
+- A Java `KeyStore` (default type, e.g. BKS), file `knownServers.bks`, stored via
+  `context.getFilesDir()` / `context.openFileOutput(..., MODE_PRIVATE)` — app-private storage.
+- KeyStore password is the hardcoded literal `"password"` (`LOCAL_TRUSTSTORE_PASSWORD`) — low
+  real-world impact since the file is already sandboxed, but sloppy.
+- Alias = `Integer.toString(certificate.hashCode())`.
+
+**Scope: per-certificate, not per-(host, certificate).**
+
+- Trust is keyed only by the certificate itself — `isKnownServer()` never looks at the
+  hostname/authType argument.
+- **Security tradeoff to flag if copying this pattern:** once a cert is accepted for any host,
+  that exact certificate is silently trusted for *any* host that later presents it, and the bypass
+  skips expiry re-validation too — an expired-but-previously-accepted cert is trusted forever with
+  no re-check. A host-bound design (store `(hostname, fingerprint)` pairs, not just fingerprint)
+  would be safer than what's here.
+
+**Nothing found:** no `CertificatePinner`/fixed-CA pinning, and no documented "we refuse to
+support self-signed certs" rationale in code comments — the repo actively supports this via the
+two layers above rather than punting to pattern A.
+
+---
+
+## owncloud-android
+
+_Not yet investigated._
+
+## jellyfin-android
+
+**Pattern used:** (B) — app-wide `network_security_config.xml` trusting user-installed CAs. No
+custom `TrustManager`, no TOFU flow, no per-server certificate pinning.
+
+**Evidence:**
+
+- File: `app/src/main/res/xml/network_security_config.xml`, wired via
+  `android:networkSecurityConfig="@xml/network_security_config"` in
+  `app/src/main/AndroidManifest.xml:43`.
+- Scope: a single global `<base-config>` — all domains (no `<domain-config>`), all build types (no
+  `<debug-overrides>` anywhere in the tree).
+- Trust anchors: `src="system"` and `src="user"` together, plus `cleartextTrafficPermitted="true"`,
+  all at the same global base-config level.
+- No custom trust manager anywhere — grepped `TrustManager`, `X509TrustManager`, `SSLContext`,
+  `CertificatePinner`, `HostnameVerifier`: zero hits outside the network security config. The
+  `OkHttpClient` for API calls (`app/src/main/java/org/jellyfin/mobile/app/AppModule.kt:65`) is
+  instantiated with no customization, purely inheriting the OS-level trust decision.
+- **WebView layer is stricter and inconsistent with the native path.** The in-app WebView (loads
+  the Jellyfin web client UI) hard-fails on SSL errors: `JellyfinWebViewClient.onReceivedSslError()`
+  (`app/src/main/java/org/jellyfin/mobile/webapp/JellyfinWebViewClient.kt:109-112`) always calls
+  `handler.cancel()`, only logging via `Timber.e`. No trust dialog, no fingerprint/issuer display,
+  no accept/reject — SSL errors here fail regardless of what the network security config allows for
+  native traffic.
+- No documentation of the tradeoff in README/CONTRIBUTING/any `.md` at time of search.
+
+**Tradeoffs worth flagging before copying this pattern:**
+
+- Native (OkHttp) and WebView traffic run under **two different, inconsistent trust policies** —
+  API/streaming calls trust user-installed CAs, the embedded web UI does not.
+- `src="user"` trust is global to the app, not scoped to the user's own server domain — any CA
+  installed on the device (including ones added for unrelated apps or a MITM proxy) is trusted for
+  every domain this app talks to, no per-host isolation.
+- No visibility into what certificate was actually presented, no revocation path other than
+  removing the CA from Android system settings.
+- Simplest of the patterns seen so far to implement, but weaker isolation and no user-facing
+  transparency compared to Nextcloud's TOFU/pinning approach.
+
+## syncthing-android
+
+**Not directly applicable — different problem shape entirely.** This app doesn't connect to an
+arbitrary remote server the user specifies; it bundles the Syncthing daemon as a **local
+subprocess** and talks to it over `https://127.0.0.1:<port>` only. The "server" is spawned by the
+app itself, so client and server are both controlled by the same install. Repo is archived; the
+Google Play removal that led here was an unrelated storage-permission (`MANAGE_EXTERNAL_STORAGE`)
+policy dispute, not anything to do with cert trust.
+
+**What it does instead: fixed single-cert pinning to a self-generated cert.**
+
+- **Files:** `SyncthingTrustManager.java` (custom `X509TrustManager`); `ApiRequest.java`
+  (`getSslSocketFactory()` — wires it into the `SSLContext`/`SSLSocketFactory` for all REST calls
+  via Volley); `WebGuiActivity.java` (`loadCaCert()` — separately trusts the same cert for the
+  embedded WebView); `Constants.java` (cert/key file locations); `SyncthingService.java` (the
+  bundled `syncthing` binary generates `https-cert.pem`/`https-key.pem` on first run).
+- **Trust decision** (`SyncthingTrustManager.checkServerTrusted`): on every handshake, re-reads
+  `https-cert.pem` from `context.getFilesDir()` and does `cert.verify(ca.getPublicKey())` against
+  the presented chain. No chain-of-trust/CA validation, no expiry check, no revocation check — just
+  "was this signed by that one specific public key." Throws if the file is missing.
+  `checkClientTrusted` is a no-op (irrelevant, no client certs used).
+- **Hostname verification is explicitly disabled** (`setHostnameVerifier((h, s) -> true)`) — only
+  defensible because the target is hardcoded to loopback.
+- **No TOFU UI at all.** The app never fetches a cert over the network and asks the user to accept
+  it — it silently trusts whatever its own child process wrote to its own private storage. No
+  "first connect" moment from the user's perspective.
+- Private key stored as a plain file in app-private storage, not Android Keystore.
+- **No `network_security_config.xml` anywhere in the repo.**
+
+**Why this isn't a useful reference for pattern C:** no per-host cert store, no fingerprint
+display, no accept/reject UX, no handling of multiple remote servers, no pin rotation/expiry/
+revocation — none of what TaigaMobileNova would actually need. The one transferable piece is the
+mechanical plumbing (`ApiRequest.getSslSocketFactory` — custom `TrustManager` wired into `OkHttp`/
+`SSLContext`), as a starting point for building a real per-host pinning store on top. **Do not
+copy the disabled hostname verification** — safe only because this app's target is always
+loopback; carrying it over to a remote-server scenario would be a real vulnerability.
+
+## home-assistant-android
+
+**Pattern used:** (B) — app-wide `network_security_config.xml` trusting user-installed CAs, plus a
+custom fallback trust manager to work around specific ROMs that don't honor `src="user"` through
+the standard path. No TOFU/pinning (pattern C) anywhere — `CertificatePinner` is never referenced.
+User-facing behavior on failure is closer to pattern A's (static error string, no cert detail
+shown), even though the underlying trust config is pattern B.
+
+**Evidence:**
+
+- `app/src/main/res/xml/network_security_config.xml` (+ same for `wear/`; automotive reuses
+  `:app`'s):
+  ```xml
+  <base-config cleartextTrafficPermitted="true">
+      <trust-anchors>
+          <certificates src="system"/>
+          <certificates src="user"/>
+      </trust-anchors>
+  </base-config>
+  ```
+  Global, applies to release builds (no `<debug-overrides>`), not domain-scoped.
+  `cleartextTrafficPermitted="true"` is also global.
+- `common/src/main/kotlin/.../data/TLSHelper.kt`: configures OkHttp's `SSLContext`. Uses the
+  platform default `X509TrustManager` (honors the config above) as primary, wrapped in
+  `CompositeX509ExtendedTrustManager` with a **fallback** trust manager built only from
+  `AndroidCAStore` `"user:"`-prefixed aliases — added because some ROMs (e.g. /e/OS, per referenced
+  issues #6810/#5565) don't apply user-installed CAs through the standard trust-manager path even
+  though their WebView/browser does.
+- `CompositeX509ExtendedTrustManager.kt`: tries the primary trust manager first; only on
+  `CertificateException` does it retry the user-CA-only fallback. **Not "always intercept"** — it
+  defers to the system path first. Client-cert checks (mTLS) always go through the primary only.
+- Also present, unrelated to server trust: mTLS client-certificate support via an
+  `X509ExtendedKeyManager` sourced from `KeyChainRepository`/keystore.
+
+**Where trust decisions are persisted:** nowhere in the app. No local file/DB/Keystore entry for
+"user accepted cert X for host Y" — trust is entirely delegated to Android's OS-level CA stores
+(system + user, the latter managed by the user outside the app via
+`Settings > Security > Encryption & credentials`). Global to the device, not per-server.
+
+**Tradeoffs worth flagging before copying this pattern:**
+
+- No user visibility into *which* certificate was trusted — no fingerprint/issuer/chain shown
+  anywhere, no in-app confirmation step. Materially weaker than TOFU: a rogue CA installed on the
+  device by any means is trusted by this app too, with zero extra friction.
+- Global, not per-server — trusting a user CA at the OS level trusts it for the whole device and
+  every server this app talks to, not just "my self-hosted instance."
+- `cleartextTrafficPermitted="true"` app-wide is a separate relaxation bundled into the same config
+  file, worth noting if copying it wholesale.
+- The `CompositeX509ExtendedTrustManager` fallback is a documented *deliberate widening* of trust
+  to work around broken ROMs specifically — not a considered design for the self-signed-cert UX
+  problem, and doesn't help a user who hasn't installed the CA at all.
+- No documented rationale anywhere against per-server pinning — the cited issues are about
+  user-CA-store reliability on specific ROMs, not a considered rejection of TOFU.
+
+## Other candidates from the initial survey
+
+_Not yet investigated: immich-app/immich (mobile/), advplyr/audiobookshelf-app._
+
+---
+
+## Open questions / things to decide later
+
+- If we copy the TOFU approach, should trust be scoped per-`(host, fingerprint)` rather than
+  per-fingerprint alone, to avoid Nextcloud's cross-host trust leak?
+- Should an accepted cert's expiry still be re-checked on every connection, even after the initial
+  TOFU acceptance?
+- Where would the pinned-cert store live in this app's architecture — `AuthStorage`? A new
+  storage class alongside it?

--- a/docs/private-cert-trust/server-setup.md
+++ b/docs/private-cert-trust/server-setup.md
@@ -1,0 +1,138 @@
+# Server-Side Setup for Manual QA
+
+This doc is a self-contained brief for another agent (or the same agent in a fresh session) to set
+up the test server needed for **Phase 5 manual QA** of the private-CA/self-signed certificate trust
+feature (see `plan.md` in this folder — all of Phases 1–4 are implemented and unit-tested; only the
+manual device/emulator repro is outstanding).
+
+## Context
+
+TaigaMobileNova (this repo) now supports trust-on-first-use (TOFU) certificate pinning: when the
+app connects to a Taiga server whose TLS certificate isn't trusted by Android's default CA store
+(self-signed, or issued by a private CA), it should show a dialog with the certificate's
+issuer/subject/validity/SHA-256 fingerprint and let the user accept it. On accept, the app pins that
+exact `(host, fingerprint)` pair and retries the login. See `research.md` for the background
+(originally reported in [#322](https://github.com/Grigoriym/TaigaMobileNova/issues/322)) and
+`plan.md` for the implementation details.
+
+**What this doc is for:** setting up a Taiga instance reachable over HTTPS with a certificate the
+device does **not** already trust, so the new flow can actually be exercised end-to-end.
+
+## Goal
+
+Get to a state where:
+
+1. A Taiga instance is reachable at `https://<some-host>:<some-port>/`.
+2. The certificate presented there is signed by a private CA that has **not** been installed
+   anywhere on the test device/emulator.
+3. The app's login screen can be pointed at that URL to trigger the untrusted-cert path.
+
+You do **not** need a fully-configured, feature-complete Taiga instance — the TLS handshake fails
+(or the pinning check runs) before any Taiga API call actually needs to succeed, so a minimal or
+even partially-broken backend behind the proxy is fine for the connection-failure/dialog part of
+the test. A working backend only matters for confirming that *retry-after-accept* actually logs in.
+
+## Steps
+
+### 1. Generate a private CA and a leaf certificate
+
+```bash
+# Private CA
+openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes \
+  -keyout ca-key.pem -out ca-cert.pem -subj "/CN=Home Lab Test CA"
+
+# Server key + CSR — CN/SAN must match whatever host you'll actually connect to.
+# Use your machine's LAN IP for a physical device, or 10.0.2.2 for the standard Android
+# Studio emulator (its alias for the host machine's loopback).
+openssl req -newkey rsa:2048 -nodes -keyout server-key.pem -out server.csr \
+  -subj "/CN=<TARGET_IP>"
+
+echo "subjectAltName=IP:<TARGET_IP>" > san.cnf
+
+openssl x509 -req -in server.csr -CA ca-cert.pem -CAkey ca-key.pem \
+  -CAcreateserial -out server-cert.pem -days 825 -sha256 -extfile san.cnf
+```
+
+Replace `<TARGET_IP>` with the actual address you'll type into the app's login screen.
+
+### 2. Find the existing local Taiga instance
+
+The user has a Taiga instance already running locally via `docker compose` (referenced earlier as
+"on localhost through docker compose on this machine"). Before doing anything else:
+
+- Run `docker compose ps` (or `docker ps`) to find the running Taiga containers and figure out
+  which service is the HTTP entry point (commonly a gateway/nginx/taiga-front-facing service on
+  port 80 or similar) and which Docker network it's on.
+- **Do not modify that compose file's own service definitions.** The goal is to add a *new*,
+  separate TLS-terminating reverse proxy sitting in front of it, so the existing plain-HTTP local
+  setup keeps working unmodified for normal development use.
+
+### 3. Add a throwaway TLS-terminating reverse proxy
+
+Drop a standalone nginx (or Caddy) container on the same Docker network as the existing Taiga
+services, terminating TLS with the certificate from step 1 and proxying to whatever the existing
+gateway/frontend service is:
+
+```nginx
+server {
+    listen 8443 ssl;
+    ssl_certificate     /certs/server-cert.pem;
+    ssl_certificate_key /certs/server-key.pem;
+    location / {
+        proxy_pass http://<existing-gateway-service-name>:80;
+    }
+}
+```
+
+```bash
+docker run -d --network <taiga-compose-network> -p 8443:8443 \
+  -v $(pwd)/certs:/certs:ro \
+  -v $(pwd)/nginx.conf:/etc/nginx/conf.d/default.conf:ro \
+  nginx
+```
+
+Adjust the proxied service name/port to whatever step 2 actually found — don't assume a name.
+
+### 4. Verify the proxy works before involving the app at all
+
+```bash
+curl -vk https://<TARGET_IP>:8443/
+```
+
+Confirm you get a TLS handshake and *some* HTTP response (even an error page from Taiga is fine —
+it proves the proxy chain works). `-k` is required here since curl doesn't trust the private CA
+either, which is expected.
+
+### 5. Do NOT install the CA on the test device
+
+This is the whole point of the test — leaving `ca-cert.pem` uninstalled on the device/emulator is
+what reproduces the "untrusted certificate" path. Do not add it to the system or user trust store.
+
+## What to check once the server is up
+
+Hand back to whoever is doing the actual app-side manual QA (or continue yourself if you're also
+driving the Android build/emulator):
+
+1. Enter `https://<TARGET_IP>:8443/` as the server URL on the login screen and attempt to log in.
+2. **Expect:** the new "Untrusted certificate" dialog appears, showing issuer/subject/validity
+   dates/SHA-256 fingerprint matching what `openssl x509 -in server-cert.pem -noout -fingerprint
+   -sha256` reports for the leaf cert.
+3. Tap **dismiss/no** → confirm the login just fails normally (no crash, no infinite spinner), and
+   nothing was persisted (a second login attempt shows the same dialog again).
+4. Retry, this time tap **confirm/yes** → confirm the login request retries automatically and either
+   succeeds (if the backend behind the proxy is a real working Taiga instance with valid
+   credentials) or fails with a normal Taiga auth error (wrong credentials) — but critically, it
+   should **not** show the untrusted-cert dialog again on that retry, since the cert is now pinned.
+5. Restart the app (fresh process) and log in again with the same server URL → the dialog should
+   **not** reappear, confirming the pin persisted across process restarts (it's backed by
+   `DataStore`, not in-memory state).
+6. Optional stronger check: change `server-cert.pem`'s SAN or regenerate a different leaf cert for
+   the same host, restart the proxy, and confirm the dialog reappears — proving the pin is scoped to
+   the specific certificate, not just the host.
+
+## Explicitly out of scope for this setup task
+
+- Don't touch the real docker-compose Taiga configuration's own ports/services.
+- Don't install the CA anywhere on the test device.
+- No need to make the backend behind the proxy fully functional — a real login success (step 4) is
+  a nice-to-have confirmation, not a blocker for validating the dialog/pinning behavior itself.

--- a/feature/login/ui/build.gradle.kts
+++ b/feature/login/ui/build.gradle.kts
@@ -10,6 +10,7 @@ kotlin {
         commonMain.dependencies {
             implementation(projects.strings)
             implementation(projects.core.api)
+            implementation(projects.core.domain)
             implementation(projects.core.storage)
             implementation(projects.core.navigation)
             implementation(projects.utils.ui)

--- a/feature/login/ui/src/commonMain/kotlin/com/grappim/taigamobile/feature/login/ui/LoginScreen.kt
+++ b/feature/login/ui/src/commonMain/kotlin/com/grappim/taigamobile/feature/login/ui/LoginScreen.kt
@@ -52,6 +52,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.grappim.taigamobile.feature.login.domain.model.AuthType
 import com.grappim.taigamobile.strings.RString
 import com.grappim.taigamobile.strings.generated.resources.app_name
+import com.grappim.taigamobile.strings.generated.resources.cert_trust_dialog_description
+import com.grappim.taigamobile.strings.generated.resources.cert_trust_dialog_title
 import com.grappim.taigamobile.strings.generated.resources.login_alert_text
 import com.grappim.taigamobile.strings.generated.resources.login_alert_title
 import com.grappim.taigamobile.strings.generated.resources.login_continue
@@ -116,6 +118,24 @@ fun LoginScreen(
         onDismiss = { state.setIsAlertVisible(false) },
         iconId = RDrawable.ic_insecure,
         isVisible = state.isAlertVisible
+    )
+    ConfirmActionDialog(
+        title = stringResource(RString.cert_trust_dialog_title),
+        description = state.pendingCertTrust?.let {
+            stringResource(
+                RString.cert_trust_dialog_description,
+                it.host,
+                it.issuer,
+                it.subject,
+                it.notBefore,
+                it.notAfter,
+                it.sha256Fingerprint
+            )
+        },
+        onConfirm = state.onConfirmCertTrust,
+        onDismiss = state.onDismissCertTrust,
+        iconId = RDrawable.ic_insecure,
+        isVisible = state.isCertTrustDialogVisible
     )
 
     LoginScreenContent(
@@ -359,7 +379,9 @@ private fun LoginScreenPreview() {
                 authType = AuthType.NORMAL,
                 onAuthTypeChange = {},
                 setIsPasswordVisible = {},
-                onGithubLoginClick = {}
+                onGithubLoginClick = {},
+                onConfirmCertTrust = {},
+                onDismissCertTrust = {}
             )
         )
     }
@@ -386,7 +408,9 @@ private fun LoginScreenErrorsPreview() {
                 authType = AuthType.NORMAL,
                 onAuthTypeChange = {},
                 setIsPasswordVisible = {},
-                onGithubLoginClick = {}
+                onGithubLoginClick = {},
+                onConfirmCertTrust = {},
+                onDismissCertTrust = {}
             )
         )
     }
@@ -413,7 +437,9 @@ private fun LoginScreenAlertPreview() {
                 authType = AuthType.NORMAL,
                 onAuthTypeChange = {},
                 setIsPasswordVisible = {},
-                onGithubLoginClick = {}
+                onGithubLoginClick = {},
+                onConfirmCertTrust = {},
+                onDismissCertTrust = {}
             )
         )
     }

--- a/feature/login/ui/src/commonMain/kotlin/com/grappim/taigamobile/feature/login/ui/LoginState.kt
+++ b/feature/login/ui/src/commonMain/kotlin/com/grappim/taigamobile/feature/login/ui/LoginState.kt
@@ -1,5 +1,6 @@
 package com.grappim.taigamobile.feature.login.ui
 
+import com.grappim.taigamobile.core.domain.PendingCertTrust
 import com.grappim.taigamobile.feature.login.domain.model.AuthType
 import com.grappim.taigamobile.strings.RString
 import com.grappim.taigamobile.strings.generated.resources.login_github_setup_guide_url
@@ -36,5 +37,10 @@ data class LoginState(
 
     val onGithubLoginClick: () -> Unit,
 
-    val githubSetupGuideUrl: NativeText = NativeText.Resource(RString.login_github_setup_guide_url)
+    val githubSetupGuideUrl: NativeText = NativeText.Resource(RString.login_github_setup_guide_url),
+
+    val isCertTrustDialogVisible: Boolean = false,
+    val pendingCertTrust: PendingCertTrust? = null,
+    val onConfirmCertTrust: () -> Unit,
+    val onDismissCertTrust: () -> Unit
 )

--- a/feature/login/ui/src/commonMain/kotlin/com/grappim/taigamobile/feature/login/ui/LoginViewModel.kt
+++ b/feature/login/ui/src/commonMain/kotlin/com/grappim/taigamobile/feature/login/ui/LoginViewModel.kt
@@ -3,7 +3,9 @@ package com.grappim.taigamobile.feature.login.ui
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.grappim.taigamobile.core.api.ApiConstants
+import com.grappim.taigamobile.core.domain.UntrustedCertificateNetworkException
 import com.grappim.taigamobile.core.logger.logcat
+import com.grappim.taigamobile.core.storage.cert.TrustedCertStorage
 import com.grappim.taigamobile.core.storage.server.ServerStorage
 import com.grappim.taigamobile.feature.login.domain.model.AuthData
 import com.grappim.taigamobile.feature.login.domain.model.AuthType
@@ -21,7 +23,11 @@ import kotlinx.coroutines.launch
 import org.koin.core.annotation.KoinViewModel
 
 @KoinViewModel
-class LoginViewModel(private val authRepository: AuthRepository, serverStorage: ServerStorage) : ViewModel() {
+class LoginViewModel(
+    private val authRepository: AuthRepository,
+    serverStorage: ServerStorage,
+    private val trustedCertStorage: TrustedCertStorage
+) : ViewModel() {
 
     companion object {
         private const val SERVER_REGEX = """(http|https)://([\w\d-]+\.)+[\w\d-]+(:\d+)?(/\w+)*/?"""
@@ -35,6 +41,10 @@ class LoginViewModel(private val authRepository: AuthRepository, serverStorage: 
     private val _openGithubWebView = Channel<String>(Channel.BUFFERED)
     val openGithubWebView = _openGithubWebView.receiveAsFlow()
 
+    // Set together with LoginState.pendingCertTrust whenever a request fails on an untrusted
+    // certificate, so onConfirmCertTrust can re-run the exact request that just failed.
+    private var pendingRetry: (() -> Unit)? = null
+
     private val _state = MutableStateFlow(
         LoginState(
             server = serverStorage.server,
@@ -46,7 +56,9 @@ class LoginViewModel(private val authRepository: AuthRepository, serverStorage: 
             validateAuthData = ::validateAuthData,
             onAuthTypeChange = ::onAuthTypeChange,
             setIsPasswordVisible = ::changePasswordVisibility,
-            onGithubLoginClick = ::validateGithubAuth
+            onGithubLoginClick = ::validateGithubAuth,
+            onConfirmCertTrust = ::onConfirmCertTrust,
+            onDismissCertTrust = ::onDismissCertTrust
         )
     )
     val state = _state.asStateFlow()
@@ -75,9 +87,7 @@ class LoginViewModel(private val authRepository: AuthRepository, serverStorage: 
                     isLoading(false)
                     _loginSuccessful.emit(true)
                 }.onFailure { error ->
-                    logcat(throwable = error) { "Login error" }
-                    isLoading(false)
-                    _state.update { it.copy(error = getErrorMessage(error)) }
+                    handleFailure(error, "Login error") { login(authData) }
                 }
         }
     }
@@ -140,9 +150,7 @@ class LoginViewModel(private val authRepository: AuthRepository, serverStorage: 
                     _openGithubWebView.send(GITHUB_OAUTH_URL.replace("%CLIENT_ID%", clientId))
                 }
                 .onFailure { error ->
-                    logcat(throwable = error) { "GitHub OAuth error" }
-                    isLoading(false)
-                    _state.update { it.copy(error = getErrorMessage(error)) }
+                    handleFailure(error, "GitHub OAuth error") { startGithubOAuth() }
                 }
         }
     }
@@ -157,11 +165,38 @@ class LoginViewModel(private val authRepository: AuthRepository, serverStorage: 
                     _loginSuccessful.emit(true)
                 }
                 .onFailure { error ->
-                    logcat(throwable = error) { "GitHub auth error" }
-                    isLoading(false)
-                    _state.update { it.copy(error = getErrorMessage(error)) }
+                    handleFailure(error, "GitHub auth error") { authWithGithub(code) }
                 }
         }
+    }
+
+    private fun handleFailure(error: Throwable, logMessage: String, retry: () -> Unit) {
+        logcat(throwable = error) { logMessage }
+        isLoading(false)
+        if (error is UntrustedCertificateNetworkException) {
+            pendingRetry = retry
+            _state.update {
+                it.copy(pendingCertTrust = error.pendingCertTrust, isCertTrustDialogVisible = true)
+            }
+        } else {
+            _state.update { it.copy(error = getErrorMessage(error)) }
+        }
+    }
+
+    private fun onConfirmCertTrust() {
+        val pendingCertTrust = _state.value.pendingCertTrust ?: return
+        val retry = pendingRetry
+        pendingRetry = null
+        _state.update { it.copy(isCertTrustDialogVisible = false, pendingCertTrust = null) }
+        viewModelScope.launch {
+            trustedCertStorage.trust(pendingCertTrust)
+            retry?.invoke()
+        }
+    }
+
+    private fun onDismissCertTrust() {
+        pendingRetry = null
+        _state.update { it.copy(isCertTrustDialogVisible = false, pendingCertTrust = null) }
     }
 
     private fun isLoading(isLoading: Boolean) {

--- a/feature/login/ui/src/commonTest/kotlin/com/grappim/taigamobile/feature/login/ui/LoginViewModelTest.kt
+++ b/feature/login/ui/src/commonTest/kotlin/com/grappim/taigamobile/feature/login/ui/LoginViewModelTest.kt
@@ -3,11 +3,14 @@
 package com.grappim.taigamobile.feature.login.ui
 
 import app.cash.turbine.test
+import com.grappim.taigamobile.core.domain.PendingCertTrust
+import com.grappim.taigamobile.core.domain.UntrustedCertificateNetworkException
 import com.grappim.taigamobile.feature.login.domain.model.AuthData
 import com.grappim.taigamobile.feature.login.domain.model.AuthType
 import com.grappim.taigamobile.testing.MainDispatcherRule
 import com.grappim.taigamobile.testing.repo.FakeAuthRepository
 import com.grappim.taigamobile.testing.storage.FakeServerStorage
+import com.grappim.taigamobile.testing.storage.FakeTrustedCertStorage
 import com.grappim.taigamobile.testing.utils.getRandomString
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -16,6 +19,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 internal class LoginViewModelTest {
@@ -27,13 +31,14 @@ internal class LoginViewModelTest {
     private val authRepository = FakeAuthRepository()
     private val defaultServer = getRandomString()
     private val serverStorage = FakeServerStorage(defaultServer)
+    private val trustedCertStorage = FakeTrustedCertStorage()
 
     private val correctServer = "https://10.0.2.2:9000"
 
     @BeforeTest
     fun setup() {
         mainDispatcherRule.setup()
-        sut = LoginViewModel(authRepository, serverStorage)
+        sut = LoginViewModel(authRepository, serverStorage, trustedCertStorage)
     }
 
     @AfterTest
@@ -273,5 +278,78 @@ internal class LoginViewModelTest {
 
         assertEquals(newServerValue, sut.state.value.server)
         assertFalse(sut.state.value.isServerInputError)
+    }
+
+    private fun pendingCertTrust(host: String = "taiga.example.com") = PendingCertTrust(
+        host = host,
+        subject = "CN=$host",
+        issuer = "CN=Home Lab CA",
+        notBefore = "2026-01-01",
+        notAfter = "2027-01-01",
+        sha256Fingerprint = "AA:BB:CC"
+    )
+
+    @Test
+    fun `login failing with an untrusted certificate shows the cert trust dialog instead of the error state`() =
+        runTest {
+            val certTrust = pendingCertTrust()
+            authRepository.authResult = Result.failure(UntrustedCertificateNetworkException(certTrust))
+            sut.state.value.onServerValueChange(correctServer)
+            sut.state.value.onAuthTypeChange(AuthType.LDAP)
+            sut.state.value.onPasswordValueChange(getRandomString())
+            sut.state.value.onLoginValueChange(getRandomString())
+
+            sut.state.value.onActionDialogConfirm()
+
+            assertTrue(sut.state.value.isCertTrustDialogVisible)
+            assertEquals(certTrust, sut.state.value.pendingCertTrust)
+            assertTrue(sut.state.value.error.isEmpty())
+            assertFalse(sut.state.value.isLoading)
+        }
+
+    @Test
+    fun `dismissing the cert trust dialog clears it without trusting or retrying`() = runTest {
+        val certTrust = pendingCertTrust()
+        authRepository.authResult = Result.failure(UntrustedCertificateNetworkException(certTrust))
+        sut.state.value.onServerValueChange(correctServer)
+        sut.state.value.onAuthTypeChange(AuthType.LDAP)
+        sut.state.value.onPasswordValueChange(getRandomString())
+        sut.state.value.onLoginValueChange(getRandomString())
+        sut.state.value.onActionDialogConfirm()
+
+        sut.state.value.onDismissCertTrust()
+
+        assertFalse(sut.state.value.isCertTrustDialogVisible)
+        assertNull(sut.state.value.pendingCertTrust)
+        assertEquals(1, authRepository.authCallCount)
+        assertFalse(trustedCertStorage.isTrusted(certTrust.host, certTrust.sha256Fingerprint))
+    }
+
+    @Test
+    fun `confirming the cert trust dialog persists the pin and retries the login`() = runTest {
+        val server = correctServer
+        val authType = AuthType.LDAP
+        val password = getRandomString()
+        val username = getRandomString()
+        val certTrust = pendingCertTrust(host = server.removePrefix("https://").substringBefore(":"))
+        authRepository.authResult = Result.failure(UntrustedCertificateNetworkException(certTrust))
+        sut.state.value.onServerValueChange(server)
+        sut.state.value.onAuthTypeChange(authType)
+        sut.state.value.onPasswordValueChange(password)
+        sut.state.value.onLoginValueChange(username)
+        sut.state.value.onActionDialogConfirm()
+
+        authRepository.authResult = Result.success(Unit)
+
+        sut.loginSuccessful.test {
+            sut.state.value.onConfirmCertTrust()
+
+            assertTrue(awaitItem())
+        }
+
+        assertFalse(sut.state.value.isCertTrustDialogVisible)
+        assertNull(sut.state.value.pendingCertTrust)
+        assertEquals(2, authRepository.authCallCount)
+        assertTrue(trustedCertStorage.isTrusted(certTrust.host, certTrust.sha256Fingerprint))
     }
 }

--- a/feature/settings/ui/src/commonMain/kotlin/com/grappim/taigamobile/feature/settings/ui/SettingsScreen.kt
+++ b/feature/settings/ui/src/commonMain/kotlin/com/grappim/taigamobile/feature/settings/ui/SettingsScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Abc
 import androidx.compose.material.icons.filled.Description
 import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.outlined.TouchApp
 import androidx.compose.material3.Icon
@@ -32,6 +33,7 @@ import com.grappim.taigamobile.strings.generated.resources.settings_attributes
 import com.grappim.taigamobile.strings.generated.resources.settings_interface
 import com.grappim.taigamobile.strings.generated.resources.settings_modules
 import com.grappim.taigamobile.strings.generated.resources.settings_project_details
+import com.grappim.taigamobile.strings.generated.resources.settings_trusted_certificates
 import com.grappim.taigamobile.strings.generated.resources.settings_user
 import com.grappim.taigamobile.uikit.generated.resources.ic_brick
 import com.grappim.taigamobile.uikit.theme.TaigaMobileTheme
@@ -54,6 +56,7 @@ fun SettingsScreen(
     goToAttributesScreen: () -> Unit,
     goToProjectDetailsScreen: () -> Unit,
     goToModulesScreen: () -> Unit,
+    goToTrustedCertificatesScreen: () -> Unit,
     viewModel: SettingsViewModel = koinViewModel()
 ) {
     val topBarController = LocalTopBarConfig.current
@@ -75,7 +78,8 @@ fun SettingsScreen(
         goToUserScreen = goToUserScreen,
         goToAttributesScreen = goToAttributesScreen,
         goToProjectDetailsScreen = goToProjectDetailsScreen,
-        goToModulesScreen = goToModulesScreen
+        goToModulesScreen = goToModulesScreen,
+        goToTrustedCertificatesScreen = goToTrustedCertificatesScreen
     )
 }
 
@@ -87,7 +91,8 @@ fun SettingsScreenContent(
     goToUserScreen: () -> Unit = {},
     goToAttributesScreen: () -> Unit = {},
     goToProjectDetailsScreen: () -> Unit = {},
-    goToModulesScreen: () -> Unit = {}
+    goToModulesScreen: () -> Unit = {},
+    goToTrustedCertificatesScreen: () -> Unit = {}
 ) {
     Surface {
         Column(
@@ -175,6 +180,22 @@ fun SettingsScreenContent(
                     Icon(
                         imageVector = Icons.Outlined.TouchApp,
                         contentDescription = "Interface Screen"
+                    )
+                }
+            )
+
+            ListItem(
+                modifier = Modifier
+                    .clickable {
+                        goToTrustedCertificatesScreen()
+                    },
+                headlineContent = {
+                    Text(text = stringResource(RString.settings_trusted_certificates))
+                },
+                leadingContent = {
+                    Icon(
+                        imageVector = Icons.Default.Lock,
+                        contentDescription = "Trusted Certificates Screen"
                     )
                 }
             )

--- a/feature/settings/ui/src/commonMain/kotlin/com/grappim/taigamobile/feature/settings/ui/trustedcerts/TrustedCertificatesNavDestination.kt
+++ b/feature/settings/ui/src/commonMain/kotlin/com/grappim/taigamobile/feature/settings/ui/trustedcerts/TrustedCertificatesNavDestination.kt
@@ -1,0 +1,11 @@
+package com.grappim.taigamobile.feature.settings.ui.trustedcerts
+
+import androidx.navigation.NavController
+import kotlinx.serialization.Serializable
+
+@Serializable
+data object TrustedCertificatesNavDestination
+
+fun NavController.goToTrustedCertificatesScreen() {
+    navigate(route = TrustedCertificatesNavDestination)
+}

--- a/feature/settings/ui/src/commonMain/kotlin/com/grappim/taigamobile/feature/settings/ui/trustedcerts/TrustedCertificatesScreen.kt
+++ b/feature/settings/ui/src/commonMain/kotlin/com/grappim/taigamobile/feature/settings/ui/trustedcerts/TrustedCertificatesScreen.kt
@@ -1,0 +1,137 @@
+package com.grappim.taigamobile.feature.settings.ui.trustedcerts
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.grappim.taigamobile.core.domain.PendingCertTrust
+import com.grappim.taigamobile.strings.RString
+import com.grappim.taigamobile.strings.generated.resources.revoke_cert_text
+import com.grappim.taigamobile.strings.generated.resources.revoke_cert_title
+import com.grappim.taigamobile.strings.generated.resources.settings_trusted_certificates
+import com.grappim.taigamobile.strings.generated.resources.trusted_cert_fingerprint
+import com.grappim.taigamobile.strings.generated.resources.trusted_cert_issuer
+import com.grappim.taigamobile.strings.generated.resources.trusted_cert_valid_until
+import com.grappim.taigamobile.uikit.generated.resources.ic_delete
+import com.grappim.taigamobile.uikit.theme.TaigaMobilePreviewTheme
+import com.grappim.taigamobile.uikit.utils.PreviewTaigaDarkLight
+import com.grappim.taigamobile.uikit.utils.RDrawable
+import com.grappim.taigamobile.uikit.widgets.dialog.ConfirmActionDialog
+import com.grappim.taigamobile.uikit.widgets.emptystate.EmptyStateWidget
+import com.grappim.taigamobile.uikit.widgets.topbar.LocalTopBarConfig
+import com.grappim.taigamobile.uikit.widgets.topbar.NavigationIconConfig
+import com.grappim.taigamobile.uikit.widgets.topbar.TopBarConfig
+import com.grappim.taigamobile.utils.ui.NativeText
+import kotlinx.collections.immutable.persistentListOf
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.viewmodel.koinViewModel
+
+@Composable
+fun TrustedCertificatesScreen(viewModel: TrustedCertificatesViewModel = koinViewModel()) {
+    val topBarController = LocalTopBarConfig.current
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    LaunchedEffect(Unit) {
+        topBarController.update(
+            TopBarConfig(
+                title = NativeText.Resource(RString.settings_trusted_certificates),
+                navigationIcon = NavigationIconConfig.Back()
+            )
+        )
+    }
+
+    state.entryToRevoke?.let { entryToRevoke ->
+        ConfirmActionDialog(
+            isVisible = state.isRevokeDialogVisible,
+            title = stringResource(RString.revoke_cert_title),
+            description = stringResource(RString.revoke_cert_text, entryToRevoke.host),
+            onConfirm = { state.revokeEntry() },
+            onDismiss = { state.closeRevokeDialog() }
+        )
+    }
+
+    TrustedCertificatesScreenContent(state = state)
+}
+
+@Composable
+private fun TrustedCertificatesScreenContent(state: TrustedCertificatesState) {
+    if (state.entries.isEmpty()) {
+        EmptyStateWidget()
+    } else {
+        LazyColumn(modifier = Modifier.fillMaxSize()) {
+            items(state.entries) { entry ->
+                TrustedCertItemWidget(entry = entry, onRevokeClick = state.onRevokeClick)
+            }
+        }
+    }
+}
+
+@Composable
+private fun TrustedCertItemWidget(entry: PendingCertTrust, onRevokeClick: (PendingCertTrust) -> Unit) {
+    ListItem(
+        headlineContent = { Text(entry.host) },
+        supportingContent = {
+            Column {
+                Text(stringResource(RString.trusted_cert_issuer, entry.issuer))
+                Text(stringResource(RString.trusted_cert_valid_until, entry.notAfter))
+                Text(
+                    text = stringResource(RString.trusted_cert_fingerprint, entry.sha256Fingerprint),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        },
+        trailingContent = {
+            IconButton(onClick = { onRevokeClick(entry) }) {
+                Icon(
+                    painter = painterResource(RDrawable.ic_delete),
+                    contentDescription = "Revoke",
+                    tint = MaterialTheme.colorScheme.error
+                )
+            }
+        }
+    )
+}
+
+private fun previewCertTrust(host: String, sha256Fingerprint: String) = PendingCertTrust(
+    host = host,
+    subject = "CN=$host",
+    issuer = "CN=Home Lab Test CA",
+    notBefore = "2026-01-01",
+    notAfter = "2027-01-01",
+    sha256Fingerprint = sha256Fingerprint
+)
+
+@PreviewTaigaDarkLight
+@Composable
+private fun TrustedCertificatesScreenContentPreview() {
+    TaigaMobilePreviewTheme {
+        TrustedCertificatesScreenContent(
+            state = TrustedCertificatesState(
+                entries = persistentListOf(
+                    previewCertTrust(host = "taiga.example.com", sha256Fingerprint = "AA:BB:CC:DD"),
+                    previewCertTrust(host = "192.168.1.50", sha256Fingerprint = "11:22:33:44")
+                )
+            )
+        )
+    }
+}
+
+@PreviewTaigaDarkLight
+@Composable
+private fun TrustedCertificatesScreenEmptyPreview() {
+    TaigaMobilePreviewTheme {
+        TrustedCertificatesScreenContent(state = TrustedCertificatesState())
+    }
+}

--- a/feature/settings/ui/src/commonMain/kotlin/com/grappim/taigamobile/feature/settings/ui/trustedcerts/TrustedCertificatesState.kt
+++ b/feature/settings/ui/src/commonMain/kotlin/com/grappim/taigamobile/feature/settings/ui/trustedcerts/TrustedCertificatesState.kt
@@ -1,0 +1,15 @@
+package com.grappim.taigamobile.feature.settings.ui.trustedcerts
+
+import com.grappim.taigamobile.core.domain.PendingCertTrust
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+
+data class TrustedCertificatesState(
+    val entries: ImmutableList<PendingCertTrust> = persistentListOf(),
+
+    val onRevokeClick: (PendingCertTrust) -> Unit = {},
+    val revokeEntry: () -> Unit = {},
+    val entryToRevoke: PendingCertTrust? = null,
+    val isRevokeDialogVisible: Boolean = false,
+    val closeRevokeDialog: () -> Unit = {}
+)

--- a/feature/settings/ui/src/commonMain/kotlin/com/grappim/taigamobile/feature/settings/ui/trustedcerts/TrustedCertificatesViewModel.kt
+++ b/feature/settings/ui/src/commonMain/kotlin/com/grappim/taigamobile/feature/settings/ui/trustedcerts/TrustedCertificatesViewModel.kt
@@ -1,0 +1,49 @@
+package com.grappim.taigamobile.feature.settings.ui.trustedcerts
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.grappim.taigamobile.core.domain.PendingCertTrust
+import com.grappim.taigamobile.core.storage.cert.TrustedCertStorage
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import org.koin.core.annotation.KoinViewModel
+
+@KoinViewModel
+class TrustedCertificatesViewModel(private val trustedCertStorage: TrustedCertStorage) : ViewModel() {
+
+    private val _state = MutableStateFlow(
+        TrustedCertificatesState(
+            onRevokeClick = ::onRevokeClick,
+            revokeEntry = ::revokeEntry,
+            closeRevokeDialog = ::closeRevokeDialog
+        )
+    )
+    val state = _state.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            trustedCertStorage.getAllFlow().collect { entries ->
+                _state.update { it.copy(entries = entries.toImmutableList()) }
+            }
+        }
+    }
+
+    private fun onRevokeClick(entry: PendingCertTrust) {
+        _state.update { it.copy(entryToRevoke = entry, isRevokeDialogVisible = true) }
+    }
+
+    private fun closeRevokeDialog() {
+        _state.update { it.copy(entryToRevoke = null, isRevokeDialogVisible = false) }
+    }
+
+    private fun revokeEntry() {
+        val entry = requireNotNull(_state.value.entryToRevoke)
+        viewModelScope.launch {
+            trustedCertStorage.untrust(entry.host, entry.sha256Fingerprint)
+            _state.update { it.copy(entryToRevoke = null, isRevokeDialogVisible = false) }
+        }
+    }
+}

--- a/feature/settings/ui/src/commonTest/kotlin/com/grappim/taigamobile/feature/settings/ui/trustedcerts/TrustedCertificatesViewModelTest.kt
+++ b/feature/settings/ui/src/commonTest/kotlin/com/grappim/taigamobile/feature/settings/ui/trustedcerts/TrustedCertificatesViewModelTest.kt
@@ -1,0 +1,110 @@
+package com.grappim.taigamobile.feature.settings.ui.trustedcerts
+
+import com.grappim.taigamobile.core.domain.PendingCertTrust
+import com.grappim.taigamobile.testing.MainDispatcherRule
+import com.grappim.taigamobile.testing.storage.FakeTrustedCertStorage
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+internal class TrustedCertificatesViewModelTest {
+
+    private val trustedCertStorage = FakeTrustedCertStorage()
+    private val mainDispatcherRule = MainDispatcherRule()
+
+    private lateinit var sut: TrustedCertificatesViewModel
+
+    @BeforeTest
+    fun setup() {
+        mainDispatcherRule.setup()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        mainDispatcherRule.tearDown()
+    }
+
+    private fun createViewModel() {
+        sut = TrustedCertificatesViewModel(trustedCertStorage = trustedCertStorage)
+    }
+
+    private fun makeCertTrust(host: String, sha256Fingerprint: String) = PendingCertTrust(
+        host = host,
+        subject = "CN=$host",
+        issuer = "CN=Test CA",
+        notBefore = "2026-01-01",
+        notAfter = "2027-01-01",
+        sha256Fingerprint = sha256Fingerprint
+    )
+
+    @Test
+    fun `on init - no trusted certs - entries is empty`() {
+        createViewModel()
+
+        assertTrue(sut.state.value.entries.isEmpty())
+    }
+
+    @Test
+    fun `on init - trusted certs already stored - entries reflects them`() = runTest {
+        val entry = makeCertTrust("taiga.example.com", "AA:BB:CC")
+        trustedCertStorage.trust(entry)
+
+        createViewModel()
+
+        assertEquals(listOf(entry), sut.state.value.entries)
+    }
+
+    @Test
+    fun `onRevokeClick - sets entryToRevoke and shows dialog`() = runTest {
+        trustedCertStorage.trust(makeCertTrust("taiga.example.com", "AA:BB:CC"))
+        createViewModel()
+
+        val entry = sut.state.value.entries.first()
+        sut.state.value.onRevokeClick(entry)
+
+        with(sut.state.value) {
+            assertEquals(entry, entryToRevoke)
+            assertTrue(isRevokeDialogVisible)
+        }
+    }
+
+    @Test
+    fun `closeRevokeDialog - clears entryToRevoke and hides dialog without revoking`() = runTest {
+        trustedCertStorage.trust(makeCertTrust("taiga.example.com", "AA:BB:CC"))
+        createViewModel()
+
+        val entry = sut.state.value.entries.first()
+        sut.state.value.onRevokeClick(entry)
+        sut.state.value.closeRevokeDialog()
+
+        with(sut.state.value) {
+            assertNull(entryToRevoke)
+            assertFalse(isRevokeDialogVisible)
+        }
+        assertNull(trustedCertStorage.untrustCalledWith)
+        assertEquals(1, sut.state.value.entries.size)
+    }
+
+    @Test
+    fun `revokeEntry - removes the entry from storage and state, hides dialog`() = runTest {
+        trustedCertStorage.trust(makeCertTrust("taiga.example.com", "AA:BB:CC"))
+        trustedCertStorage.trust(makeCertTrust("other.example.com", "DD:EE:FF"))
+        createViewModel()
+
+        val entryToRevoke = sut.state.value.entries.first { it.host == "taiga.example.com" }
+        sut.state.value.onRevokeClick(entryToRevoke)
+        sut.state.value.revokeEntry()
+
+        assertEquals("taiga.example.com" to "AA:BB:CC", trustedCertStorage.untrustCalledWith)
+        with(sut.state.value) {
+            assertNull(this.entryToRevoke)
+            assertFalse(isRevokeDialogVisible)
+            assertEquals(listOf("other.example.com"), entries.map { it.host })
+        }
+    }
+}

--- a/info/local-info
+++ b/info/local-info
@@ -1,5 +1,7 @@
 This info for my local setup
 
+https://192.168.0.241:8443
+
 setup:
     https://community.taiga.io/t/taiga-30min-setup/170/1
 

--- a/strings/src/commonMain/composeResources/values/strings.xml
+++ b/strings/src/commonMain/composeResources/values/strings.xml
@@ -46,6 +46,7 @@
     <string name="error_host_not_found">Host not found</string>
     <string name="request_failed">Request ended with error</string>
     <string name="connection_failed">Connection error</string>
+    <string name="error_ssl_certificate">Can't verify the server's security certificate. If it uses a self-signed certificate or one from a private CA, this app won't trust it</string>
     <string name="timeout_exceeded">Waiting limit exceeded</string>
     <string name="auth_error_refresh_token_not_passed">For security reasons, your session was closed</string>
     <string name="error_permission_denied">You do not have permission to perform this action</string>

--- a/strings/src/commonMain/composeResources/values/strings.xml
+++ b/strings/src/commonMain/composeResources/values/strings.xml
@@ -46,7 +46,8 @@
     <string name="error_host_not_found">Host not found</string>
     <string name="request_failed">Request ended with error</string>
     <string name="connection_failed">Connection error</string>
-    <string name="error_ssl_certificate">Can't verify the server's security certificate. If it uses a self-signed certificate or one from a private CA, this app won't trust it</string>
+    <string name="error_ssl_certificate">Can't verify the server's security certificate. If it's self-signed or from a private CA, log out and log back in to trust it</string>
+    <string name="error_ssl_hostname_mismatch">The server's certificate doesn't match this address. Check the server URL, or the certificate may need to be reissued for this host</string>
     <string name="timeout_exceeded">Waiting limit exceeded</string>
     <string name="auth_error_refresh_token_not_passed">For security reasons, your session was closed</string>
     <string name="error_permission_denied">You do not have permission to perform this action</string>
@@ -76,6 +77,8 @@
     <string name="login_error_message">Error during login. Check credentials or connection</string>
     <string name="login_alert_title">Unencrypted connection</string>
     <string name="login_alert_text">You are going to use an unencrypted connection. Are you sure?</string>
+    <string name="cert_trust_dialog_title">Untrusted certificate</string>
+    <string name="cert_trust_dialog_description">The certificate presented by %1$s could not be automatically verified.\n\nIssuer: %2$s\nSubject: %3$s\nValid: %4$s – %5$s\nSHA-256: %6$s\n\nOnly continue if you trust this server.</string>
 
     <!-- ==================== Dashboard ==================== -->
     <string name="dashboard">Dashboard</string>
@@ -339,6 +342,12 @@
     <string name="settings_user">User</string>
     <string name="settings_attributes">Attributes</string>
     <string name="settings_modules">Modules</string>
+    <string name="settings_trusted_certificates">Trusted Certificates</string>
+    <string name="trusted_cert_issuer">Issued by %1$s</string>
+    <string name="trusted_cert_valid_until">Valid until %1$s</string>
+    <string name="trusted_cert_fingerprint">SHA-256: %1$s</string>
+    <string name="revoke_cert_title">Revoke trust</string>
+    <string name="revoke_cert_text">Stop trusting this certificate for %1$s? You'll need to accept it again next time you connect.</string>
     <string name="module_epics_activated">Epics</string>
     <string name="module_epics_details">Group related user stories under high-level goals</string>
     <string name="module_backlog_activated">Backlog/Scrum</string>

--- a/testing/src/commonMain/kotlin/com/grappim/taigamobile/testing/storage/FakeTrustedCertStorage.kt
+++ b/testing/src/commonMain/kotlin/com/grappim/taigamobile/testing/storage/FakeTrustedCertStorage.kt
@@ -1,0 +1,32 @@
+package com.grappim.taigamobile.testing.storage
+
+import com.grappim.taigamobile.core.domain.PendingCertTrust
+import com.grappim.taigamobile.core.storage.cert.TrustedCertStorage
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class FakeTrustedCertStorage : TrustedCertStorage {
+
+    private val trustedFlow = MutableStateFlow<List<PendingCertTrust>>(emptyList())
+    var trustCalledWith: PendingCertTrust? = null
+    var untrustCalledWith: Pair<String, String>? = null
+
+    override suspend fun isTrusted(host: String, sha256Fingerprint: String): Boolean =
+        trustedFlow.value.any { it.host == host && it.sha256Fingerprint == sha256Fingerprint }
+
+    override suspend fun trust(pendingCertTrust: PendingCertTrust) {
+        trustCalledWith = pendingCertTrust
+        trustedFlow.value = trustedFlow.value.filterNot {
+            it.host == pendingCertTrust.host && it.sha256Fingerprint == pendingCertTrust.sha256Fingerprint
+        } + pendingCertTrust
+    }
+
+    override fun getAllFlow() = trustedFlow.asStateFlow()
+
+    override suspend fun untrust(host: String, sha256Fingerprint: String) {
+        untrustCalledWith = host to sha256Fingerprint
+        trustedFlow.value = trustedFlow.value.filterNot {
+            it.host == host && it.sha256Fingerprint == sha256Fingerprint
+        }
+    }
+}

--- a/utils/ui/src/commonMain/kotlin/com/grappim/taigamobile/utils/ui/NativeText.kt
+++ b/utils/ui/src/commonMain/kotlin/com/grappim/taigamobile/utils/ui/NativeText.kt
@@ -2,6 +2,7 @@ package com.grappim.taigamobile.utils.ui
 
 import androidx.compose.runtime.Composable
 import com.grappim.taigamobile.core.domain.NetworkException
+import com.grappim.taigamobile.core.domain.UntrustedCertificateNetworkException
 import com.grappim.taigamobile.strings.RString
 import com.grappim.taigamobile.strings.generated.resources.auth_error_refresh_token_not_passed
 import com.grappim.taigamobile.strings.generated.resources.connection_failed
@@ -16,6 +17,7 @@ import com.grappim.taigamobile.strings.generated.resources.error_not_found
 import com.grappim.taigamobile.strings.generated.resources.error_permission_denied
 import com.grappim.taigamobile.strings.generated.resources.error_something_has_gone_wrong
 import com.grappim.taigamobile.strings.generated.resources.error_ssl_certificate
+import com.grappim.taigamobile.strings.generated.resources.error_ssl_hostname_mismatch
 import com.grappim.taigamobile.strings.generated.resources.error_throttled
 import com.grappim.taigamobile.strings.generated.resources.error_unsupported_media_type
 import com.grappim.taigamobile.strings.generated.resources.error_validation
@@ -115,6 +117,10 @@ fun getErrorMessage(exception: Throwable): NativeText = if (exception is Network
             RString.error_ssl_certificate
         )
 
+        NetworkException.ERROR_SSL_HOSTNAME_MISMATCH -> NativeText.Resource(
+            RString.error_ssl_hostname_mismatch
+        )
+
         NetworkException.ERROR_UNDEFINED -> NativeText.Resource(RString.request_failed)
 
         NetworkException.ERROR_UNAUTHORIZED -> NativeText.Resource(
@@ -163,6 +169,11 @@ fun getErrorMessage(exception: Throwable): NativeText = if (exception is Network
 
         else -> NativeText.Resource(RString.error_something_has_gone_wrong)
     }
+} else if (exception is UntrustedCertificateNetworkException) {
+    // Callers that specifically handle UntrustedCertificateNetworkException (e.g. the login flow)
+    // check for it before calling getErrorMessage and show a trust-this-certificate prompt instead.
+    // This is the fallback for everyone else.
+    NativeText.Resource(RString.error_ssl_certificate)
 } else {
     NativeText.Simple(exception.message.toString())
 }

--- a/utils/ui/src/commonMain/kotlin/com/grappim/taigamobile/utils/ui/NativeText.kt
+++ b/utils/ui/src/commonMain/kotlin/com/grappim/taigamobile/utils/ui/NativeText.kt
@@ -15,6 +15,7 @@ import com.grappim.taigamobile.strings.generated.resources.error_not_acceptable
 import com.grappim.taigamobile.strings.generated.resources.error_not_found
 import com.grappim.taigamobile.strings.generated.resources.error_permission_denied
 import com.grappim.taigamobile.strings.generated.resources.error_something_has_gone_wrong
+import com.grappim.taigamobile.strings.generated.resources.error_ssl_certificate
 import com.grappim.taigamobile.strings.generated.resources.error_throttled
 import com.grappim.taigamobile.strings.generated.resources.error_unsupported_media_type
 import com.grappim.taigamobile.strings.generated.resources.error_validation
@@ -109,6 +110,10 @@ fun getErrorMessage(exception: Throwable): NativeText = if (exception is Network
         NetworkException.ERROR_TIMEOUT -> NativeText.Resource(RString.timeout_exceeded)
 
         NetworkException.ERROR_NETWORK_IO -> NativeText.Resource(RString.connection_failed)
+
+        NetworkException.ERROR_SSL_CERTIFICATE -> NativeText.Resource(
+            RString.error_ssl_certificate
+        )
 
         NetworkException.ERROR_UNDEFINED -> NativeText.Resource(RString.request_failed)
 


### PR DESCRIPTION
### Be sure to run locally
1. `./gradlew ktlintFormat`
2. `./gradlew jvmTest`
3. `./gradlew :androidApp:assembleFdroidDebug`

### Describe your changes

Fixes #322 — a self-hosted Taiga instance using a cert issued by a private CA failed to connect
with an opaque "Connection error", with no way to proceed.

**1. Distinguish SSL/network errors from generic ones.** `NetworkErrorMapper` previously collapsed
`SSLHandshakeException` into the same generic I/O error bucket as any other connection failure.
Added a dedicated `ERROR_SSL_CERTIFICATE` code/message so users see what actually went wrong
instead of a generic error. Also stripped the user's own server URL out of the error message
(it was redundant — the user already knows what they typed — and unnecessary to echo back).

**2. Trust-on-first-use (TOFU) certificate pinning**, so users can actually get past an untrusted
cert instead of being stuck:
- When login hits an untrusted cert, a dialog shows the certificate's issuer, subject, validity
  dates, and SHA-256 fingerprint (reusing the existing `ConfirmActionDialog`).
- Accepting pins the exact `(host, fingerprint)` pair via a new `TrustedCertStorage`
  (`DataStore`-backed) and retries the login automatically. Rejecting just fails the login as
  before, with nothing persisted.
- Pinning is enforced by a custom `CompositeTrustManager` wired into the OkHttp engine — it checks
  the pin store before falling back to the platform's default trust manager, and re-validates
  cert expiry even on a pin hit (a previously-pinned cert doesn't get a free pass forever).
- Also guards against a cert/host mismatch (e.g. a cert issued for the wrong IP): if the presented
  cert's SAN/CN doesn't actually cover the connecting host, it's rejected with a clear
  "hostname mismatch" message instead of offering to pin a cert that could never work.
- New "Trusted Certificates" screen under Settings lists pinned hosts (issuer, expiry,
  fingerprint) with a per-row revoke action, since there was previously no way to un-pin a host
  short of clearing app data.
- Scope: Android only for now (the login dialog flow). The storage/trust-manager layer also works
  on JVM Desktop for free since it shares the OkHttp engine. iOS (Darwin engine) is untouched.

See `docs/private-cert-trust/` (`research.md`, `plan.md`) for the design survey (Nextcloud,
Jellyfin, Syncthing, Home Assistant) and full implementation notes, and `server-setup.md` for how
this was manually tested against a private-CA-signed proxy in front of a local Taiga instance.

### Additional Information

1. As a first step of improvement for https://github.com/Grigoriym/TaigaMobileNova/issues/322 let's show the exact issue in the snackbar
