### PR TITLE
docs: survey desktop Linux release readiness and plan the fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,10 +64,13 @@ jobs:
       - name: Setup Android Environment
         uses: ./.github/actions/android-setup-composite-action
 
-      - name: Install fakeroot
+      - name: Install fakeroot and rpm
         run: |
             sudo apt-get update
-            sudo apt-get install -y fakeroot
+            sudo apt-get install -y fakeroot rpm
 
       - name: Package Linux deb
         run: ./gradlew :composeApp:packageDeb
+
+      - name: Package Linux rpm
+        run: ./gradlew :composeApp:packageRpm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,3 +53,21 @@ jobs:
 
       - name: Assemble gradle gplay project
         run: ./gradlew :androidApp:assembleGplayDebug -PgplayBuild
+
+  desktop-package:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v7
+
+      - name: Setup Android Environment
+        uses: ./.github/actions/android-setup-composite-action
+
+      - name: Install fakeroot
+        run: |
+            sudo apt-get update
+            sudo apt-get install -y fakeroot
+
+      - name: Package Linux deb
+        run: ./gradlew :composeApp:packageDeb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,13 +53,16 @@ jobs:
               run: |
                   ./gradlew :androidApp:assembleGplayRelease :androidApp:bundleGplayRelease -PgplayBuild
 
-            - name: Install fakeroot
+            - name: Install fakeroot and rpm
               run: |
                   sudo apt-get update
-                  sudo apt-get install -y fakeroot
+                  sudo apt-get install -y fakeroot rpm
 
             - name: Package Linux deb
               run: ./gradlew :composeApp:packageDeb
+
+            - name: Package Linux rpm
+              run: ./gradlew :composeApp:packageRpm
 
             - name: Upload Release Build To Artifacts
               uses: actions/upload-artifact@v7
@@ -69,6 +72,7 @@ jobs:
                       androidApp/build/outputs/apk/*
                       androidApp/build/outputs/bundle/*
                       composeApp/build/compose/binaries/main/deb/*.deb
+                      composeApp/build/compose/binaries/main/rpm/*.rpm
 
             - name: Create GitHub release
               uses: softprops/action-gh-release@v3
@@ -84,3 +88,4 @@ jobs:
                       androidApp/build/outputs/apk/gplay/release/app-gplay-release.apk
                       androidApp/build/outputs/bundle/gplayRelease/androidApp-gplay-release.aab
                       composeApp/build/compose/binaries/main/deb/*.deb
+                      composeApp/build/compose/binaries/main/rpm/*.rpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,14 @@ jobs:
               run: |
                   ./gradlew :androidApp:assembleGplayRelease :androidApp:bundleGplayRelease -PgplayBuild
 
+            - name: Install fakeroot
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install -y fakeroot
+
+            - name: Package Linux deb
+              run: ./gradlew :composeApp:packageDeb
+
             - name: Upload Release Build To Artifacts
               uses: actions/upload-artifact@v7
               with:
@@ -60,6 +68,7 @@ jobs:
                   path: |
                       androidApp/build/outputs/apk/*
                       androidApp/build/outputs/bundle/*
+                      composeApp/build/compose/binaries/main/deb/*.deb
 
             - name: Create GitHub release
               uses: softprops/action-gh-release@v3
@@ -74,3 +83,4 @@ jobs:
                       androidApp/build/outputs/apk/fdroid/debug/app-fdroid-debug.apk
                       androidApp/build/outputs/apk/gplay/release/app-gplay-release.apk
                       androidApp/build/outputs/bundle/gplayRelease/androidApp-gplay-release.aab
+                      composeApp/build/compose/binaries/main/deb/*.deb

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -411,7 +411,7 @@ directly outside `core/logger`.
 |----------|------|--------------|
 | Android | `TimberLogger` → Timber (`DebugTree` on debug, `CrashlyticsTree` on gplay) | `androidApp/TaigaApp.kt` |
 | iOS | `NSLogLogger` → `NSLog`, chunked at 3000 chars to survive its ~4096-byte truncation | `main.ios.kt` |
-| Desktop/JVM | **none** — falls back to the `NoLog` no-op, so `logcat` output is silently dropped | — |
+| Desktop/JVM | `FileLogger` → appends to `taigamobile.log` in the per-user app-data dir (`core/storage`'s `appDataDir()`), rotating to `<name>.old` past 5 MB | `TaigaMobileDesktop.kt` |
 
 ## Error Handling
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,9 @@ and stop.
 - Navigation Compose (KMP) with type-safe routes
 - Kotlin Serialization for JSON
 - Coroutines, Coil 3.x for images (KMP-ready)
-- Room 2.8.4 + BundledSQLiteDriver (KMP-ready)
+- Room 2.8.4 + BundledSQLiteDriver (KMP-ready) — **`RoomDatabase.clearAllTables()` is Android-only**;
+  the JVM/native actual doesn't declare it at all (confirmed via `javap` on the `room-runtime`
+  artifacts). To clear all tables on JVM/iOS, add a no-arg `deleteAll()` `@Query` to each DAO instead.
 - `core/logger` — KMP logging facade (see Logging below); Timber backs it on Android only
 
 **Convention Plugins** (in `build-logic/`):

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ The previous author archived the original project. This version has been complet
 |----------|--------|--------------|
 | Android  | Released | Google Play & F-Droid |
 | iOS      | Builds & runs | Distribution TBD |
-| Desktop (Linux / macOS / Windows) | Builds & runs | Distribution TBD |
+| Desktop (Linux) | Released | [GitHub Releases](https://github.com/Grigoriym/TaigaMobileNova/releases) (`.deb`) |
+| Desktop (macOS / Windows) | Builds & runs | Distribution TBD |
 
 ### Android
 
@@ -23,9 +24,13 @@ height="80">](https://play.google.com/store/apps/details?id=com.grappim.taigamob
 alt="Get it on F-Droid"
 height="80">](https://f-droid.org/en/packages/com.grappim.taigamobile.fdroid/)
 
-### iOS & Desktop
+### Desktop (Linux)
 
-iOS and Desktop builds are functional but distribution channels are not yet set up. If you want to try them, clone the repo and build locally — see [Build Commands](#build-commands) below.
+Download the latest `.deb` from [GitHub Releases](https://github.com/Grigoriym/TaigaMobileNova/releases).
+
+### iOS & Desktop (macOS / Windows)
+
+iOS and Desktop (macOS / Windows) builds are functional but distribution channels are not yet set up. If you want to try them, clone the repo and build locally — see [Build Commands](#build-commands) below.
 
 [Project board](https://tasks.gregstuff.click/project/taigamobilenova/kanban)
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The previous author archived the original project. This version has been complet
 |----------|--------|--------------|
 | Android  | Released | Google Play & F-Droid |
 | iOS      | Builds & runs | Distribution TBD |
-| Desktop (Linux) | Released | [GitHub Releases](https://github.com/Grigoriym/TaigaMobileNova/releases) (`.deb`) |
+| Desktop (Linux) | Released | [GitHub Releases](https://github.com/Grigoriym/TaigaMobileNova/releases) (`.deb` / `.rpm`) |
 | Desktop (macOS / Windows) | Builds & runs | Distribution TBD |
 
 ### Android
@@ -26,7 +26,7 @@ height="80">](https://f-droid.org/en/packages/com.grappim.taigamobile.fdroid/)
 
 ### Desktop (Linux)
 
-Download the latest `.deb` from [GitHub Releases](https://github.com/Grigoriym/TaigaMobileNova/releases).
+Download the latest `.deb` (Debian/Ubuntu) or `.rpm` (Fedora/openSUSE) from [GitHub Releases](https://github.com/Grigoriym/TaigaMobileNova/releases).
 
 ### iOS & Desktop (macOS / Windows)
 

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -55,7 +55,7 @@ compose.desktop {
         nativeDistributions {
             modules("jdk.unsupported")
 
-            targetFormats(TargetFormat.Deb, TargetFormat.Dmg, TargetFormat.Msi)
+            targetFormats(TargetFormat.Deb, TargetFormat.Rpm, TargetFormat.Dmg, TargetFormat.Msi)
             packageName = libs.versions.app.name.get()
             packageVersion = libs.versions.version.name.get()
             description = libs.versions.app.description.get()

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -63,7 +63,7 @@ compose.desktop {
             copyright = "Copyright 2026 ${libs.versions.app.vendor.get()}"
 
             linux {
-                iconFile.set(project.file("../info/art/taiga-mobile-logo.png"))
+                iconFile.set(project.file("../art/taiga-mobile-logo.png"))
 
                 debMaintainer = libs.versions.app.vendor.get()
                 debPackageVersion = libs.versions.version.name.get()
@@ -72,13 +72,13 @@ compose.desktop {
                 shortcut = true
             }
             windows {
-                iconFile.set(project.file("../info/art/taiga-mobile-logo.ico"))
+                iconFile.set(project.file("../art/taiga-mobile-logo.ico"))
 
                 menuGroup = libs.versions.app.menugroup.get()
                 shortcut = true
             }
             macOS {
-                iconFile.set(project.file("../info/art/taiga-mobile-logo.icns"))
+                iconFile.set(project.file("../art/taiga-mobile-logo.icns"))
             }
         }
     }

--- a/composeApp/src/jvmMain/kotlin/com/grappim/taigamobile/TaigaMobileDesktop.kt
+++ b/composeApp/src/jvmMain/kotlin/com/grappim/taigamobile/TaigaMobileDesktop.kt
@@ -5,6 +5,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberWindowState
+import com.grappim.taigamobile.core.logger.FileLogger
+import com.grappim.taigamobile.core.storage.platform.appDataDir
 import com.grappim.taigamobile.di.KoinApp
 import com.grappim.taigamobile.main.TaigaAppContent
 import com.grappim.taigamobile.strings.RString
@@ -14,8 +16,11 @@ import io.github.vinceglb.filekit.FileKit
 import org.jetbrains.compose.resources.decodeToImageBitmap
 import org.jetbrains.compose.resources.stringResource
 import org.koin.plugin.module.dsl.startKoin
+import java.io.File
 
 fun main() {
+    FileLogger.install(File(appDataDir(), "taigamobile.log"))
+
     FileKit.init(appId = "com.grappim.taigamobile")
 
     val screenReadySignalController = ScreenReadySignalController(true)

--- a/core/logger/src/jvmMain/kotlin/com/grappim/taigamobile/core/logger/FileLogger.kt
+++ b/core/logger/src/jvmMain/kotlin/com/grappim/taigamobile/core/logger/FileLogger.kt
@@ -1,0 +1,47 @@
+package com.grappim.taigamobile.core.logger
+
+import java.io.File
+import java.io.FileWriter
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+private const val MAX_LOG_FILE_BYTES = 5L * 1024 * 1024
+private val TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")
+
+/**
+ * Writes log lines to [logFile], rotating it to `<name>.old` once it exceeds
+ * [MAX_LOG_FILE_BYTES] so a long-running desktop session can't grow the file unbounded.
+ */
+class FileLogger(private val logFile: File) : TaigaLogger {
+
+    init {
+        logFile.parentFile?.mkdirs()
+    }
+
+    override fun log(priority: LogPriority, tag: String?, throwable: Throwable?, message: () -> String) {
+        val timestamp = LocalDateTime.now().format(TIMESTAMP_FORMATTER)
+        val prefix = tag?.let { "[$it] " } ?: ""
+        val throwableText = throwable?.let { "\n${it.stackTraceToString()}" } ?: ""
+        val line = "$timestamp ${priority.name.first()}/$prefix${message()}$throwableText\n"
+        synchronized(this) {
+            if (logFile.length() > MAX_LOG_FILE_BYTES) {
+                rotate()
+            }
+            FileWriter(logFile, true).use { it.write(line) }
+        }
+    }
+
+    private fun rotate() {
+        val oldFile = File(logFile.parentFile, "${logFile.name}.old")
+        oldFile.delete()
+        logFile.renameTo(oldFile)
+    }
+
+    companion object {
+        fun install(logFile: File) {
+            if (!TaigaLogger.isInstalled) {
+                TaigaLogger.install(FileLogger(logFile))
+            }
+        }
+    }
+}

--- a/core/storage/src/androidMain/kotlin/com/grappim/taigamobile/core/storage/db/TaigaDBExt.android.kt
+++ b/core/storage/src/androidMain/kotlin/com/grappim/taigamobile/core/storage/db/TaigaDBExt.android.kt
@@ -1,3 +1,3 @@
 package com.grappim.taigamobile.core.storage.db
 
-actual fun TaigaDB.clearAllTablesKmp() = clearAllTables()
+actual suspend fun TaigaDB.clearAllTablesKmp() = clearAllTables()

--- a/core/storage/src/commonMain/kotlin/com/grappim/taigamobile/core/storage/db/TaigaDBExt.kt
+++ b/core/storage/src/commonMain/kotlin/com/grappim/taigamobile/core/storage/db/TaigaDBExt.kt
@@ -1,3 +1,3 @@
 package com.grappim.taigamobile.core.storage.db
 
-expect fun TaigaDB.clearAllTablesKmp()
+expect suspend fun TaigaDB.clearAllTablesKmp()

--- a/core/storage/src/commonMain/kotlin/com/grappim/taigamobile/core/storage/db/dao/ProjectDao.kt
+++ b/core/storage/src/commonMain/kotlin/com/grappim/taigamobile/core/storage/db/dao/ProjectDao.kt
@@ -17,4 +17,7 @@ interface ProjectDao {
 
     @Query("SELECT * FROM project_table WHERE id =:id")
     fun getProjectByIdFlow(id: Long): Flow<ProjectEntity?>
+
+    @Query("DELETE FROM project_table")
+    suspend fun deleteAll()
 }

--- a/core/storage/src/commonMain/kotlin/com/grappim/taigamobile/core/storage/db/dao/SprintDao.kt
+++ b/core/storage/src/commonMain/kotlin/com/grappim/taigamobile/core/storage/db/dao/SprintDao.kt
@@ -35,4 +35,7 @@ interface SprintDao {
 
     @Query("DELETE FROM $SPRINT_TABLE WHERE projectId = :projectId AND isClosed = :isClosed")
     suspend fun deleteByProjectIdAndClosed(projectId: Long, isClosed: Boolean)
+
+    @Query("DELETE FROM $SPRINT_TABLE")
+    suspend fun deleteAll()
 }

--- a/core/storage/src/commonMain/kotlin/com/grappim/taigamobile/core/storage/db/dao/WorkItemDao.kt
+++ b/core/storage/src/commonMain/kotlin/com/grappim/taigamobile/core/storage/db/dao/WorkItemDao.kt
@@ -56,4 +56,7 @@ interface WorkItemDao {
         "SELECT * FROM $WORK_ITEM_TABLE WHERE projectId = :projectId AND taskType = :taskType ORDER BY createdDate DESC"
     )
     fun pagingSource(projectId: Long, taskType: CommonTaskType): PagingSource<Int, WorkItemEntity>
+
+    @Query("DELETE FROM $WORK_ITEM_TABLE")
+    suspend fun deleteAll()
 }

--- a/core/storage/src/iosMain/kotlin/com/grappim/taigamobile/core/storage/db/TaigaDBExt.ios.kt
+++ b/core/storage/src/iosMain/kotlin/com/grappim/taigamobile/core/storage/db/TaigaDBExt.ios.kt
@@ -1,3 +1,3 @@
 package com.grappim.taigamobile.core.storage.db
 
-actual fun TaigaDB.clearAllTablesKmp() = Unit
+actual suspend fun TaigaDB.clearAllTablesKmp() = Unit

--- a/core/storage/src/jvmMain/kotlin/com/grappim/taigamobile/core/storage/db/TaigaDBExt.jvm.kt
+++ b/core/storage/src/jvmMain/kotlin/com/grappim/taigamobile/core/storage/db/TaigaDBExt.jvm.kt
@@ -1,3 +1,7 @@
 package com.grappim.taigamobile.core.storage.db
 
-actual fun TaigaDB.clearAllTablesKmp() = Unit
+actual suspend fun TaigaDB.clearAllTablesKmp() {
+    projectDao().deleteAll()
+    sprintDao().deleteAll()
+    workItemDao().deleteAll()
+}

--- a/core/storage/src/jvmMain/kotlin/com/grappim/taigamobile/core/storage/di/DBModule.jvm.kt
+++ b/core/storage/src/jvmMain/kotlin/com/grappim/taigamobile/core/storage/di/DBModule.jvm.kt
@@ -3,6 +3,7 @@ package com.grappim.taigamobile.core.storage.di
 import androidx.room.Room
 import androidx.room.RoomDatabase
 import com.grappim.taigamobile.core.storage.db.TaigaDB
+import com.grappim.taigamobile.core.storage.platform.appDataDir
 import org.koin.core.annotation.Configuration
 import org.koin.core.annotation.Module
 import org.koin.core.annotation.Single
@@ -13,7 +14,7 @@ import java.io.File
 actual class PlatformDBModule {
     @Single
     fun getDatabaseBuilder(): RoomDatabase.Builder<TaigaDB> {
-        val dbFile = File(System.getProperty("java.io.tmpdir"), "taigamobilenova.db")
+        val dbFile = File(appDataDir(), "taigamobilenova.db")
         return Room.databaseBuilder<TaigaDB>(
             name = dbFile.absolutePath
         )

--- a/core/storage/src/jvmMain/kotlin/com/grappim/taigamobile/core/storage/di/StorageModule.jvm.kt
+++ b/core/storage/src/jvmMain/kotlin/com/grappim/taigamobile/core/storage/di/StorageModule.jvm.kt
@@ -10,6 +10,7 @@ import com.grappim.taigamobile.core.storage.auth.AuthStorage
 import com.grappim.taigamobile.core.storage.auth.AuthStorageImpl
 import com.grappim.taigamobile.core.storage.cert.TrustedCertStorage
 import com.grappim.taigamobile.core.storage.cert.TrustedCertStorageImpl
+import com.grappim.taigamobile.core.storage.platform.appDataDir
 import com.grappim.taigamobile.utils.ui.ColorMapper
 import kotlinx.serialization.json.Json
 import org.koin.core.annotation.Configuration
@@ -42,25 +43,25 @@ class AuthDataStoreModule {
 
 fun createSessionDataStore(): DataStore<Preferences> = createDataStore(
     producePath = {
-        File(System.getProperty("java.io.tmpdir"), "$TAIGA_SESSION_STORAGE$PREFS_EXT").absolutePath
+        File(appDataDir(), "$TAIGA_SESSION_STORAGE$PREFS_EXT").absolutePath
     }
 )
 
 fun createSessionFiltersDataStore(): DataStore<Preferences> = createDataStore(
     producePath = {
         File(
-            System.getProperty("java.io.tmpdir"),
+            appDataDir(),
             "$SESSION_FILTERS_DATA_STORE_FILE_NAME$PREFS_EXT"
         ).absolutePath
     }
 )
 
 fun createAuthDataStore(): DataStore<Preferences> = createDataStore(
-    producePath = { File(System.getProperty("java.io.tmpdir"), "$AUTH_DATA_STORE_FILE_NAME$PREFS_EXT").absolutePath }
+    producePath = { File(appDataDir(), "$AUTH_DATA_STORE_FILE_NAME$PREFS_EXT").absolutePath }
 )
 
 fun createTrustedCertDataStore(): DataStore<Preferences> = createDataStore(
     producePath = {
-        File(System.getProperty("java.io.tmpdir"), "$TRUSTED_CERT_DATA_STORE_FILE_NAME$PREFS_EXT").absolutePath
+        File(appDataDir(), "$TRUSTED_CERT_DATA_STORE_FILE_NAME$PREFS_EXT").absolutePath
     }
 )

--- a/core/storage/src/jvmMain/kotlin/com/grappim/taigamobile/core/storage/network/NetworkMonitorImpl.jvm.kt
+++ b/core/storage/src/jvmMain/kotlin/com/grappim/taigamobile/core/storage/network/NetworkMonitorImpl.jvm.kt
@@ -54,6 +54,6 @@ class NetworkMonitorImpl(
 internal fun isHostReachable(host: String, port: Int, timeoutMs: Int): Boolean = try {
     Socket().use { socket -> socket.connect(InetSocketAddress(host, port), timeoutMs) }
     true
-} catch (e: IOException) {
+} catch (expected: IOException) {
     false
 }

--- a/core/storage/src/jvmMain/kotlin/com/grappim/taigamobile/core/storage/network/NetworkMonitorImpl.jvm.kt
+++ b/core/storage/src/jvmMain/kotlin/com/grappim/taigamobile/core/storage/network/NetworkMonitorImpl.jvm.kt
@@ -1,12 +1,59 @@
 package com.grappim.taigamobile.core.storage.network
 
+import com.grappim.taigamobile.core.asynckmp.ApplicationScope
+import com.grappim.taigamobile.core.asynckmp.IoDispatcher
+import com.grappim.taigamobile.core.logger.LogPriority
+import com.grappim.taigamobile.core.logger.logcat
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 import org.koin.core.annotation.Single
+import java.io.IOException
+import java.net.InetSocketAddress
+import java.net.Socket
 
+private const val CHECK_HOST = "1.1.1.1"
+private const val CHECK_PORT = 53
+private const val CONNECT_TIMEOUT_MS = 2000
+private const val CHECK_INTERVAL_MS = 5000L
+
+/**
+ * Polls TCP reachability of [CHECK_HOST] on a fixed interval, since the JVM has no OS-level
+ * connectivity-change callback API. Starts optimistic ([MutableStateFlow] seeded `true`) and
+ * corrects within one [CONNECT_TIMEOUT_MS] of startup — unlike Android's actual, which can query
+ * [android.net.ConnectivityManager] synchronously for an immediate accurate initial value.
+ */
 @Single(binds = [NetworkMonitor::class])
-class NetworkMonitorImpl : NetworkMonitor {
+class NetworkMonitorImpl(
+    @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+    @param:ApplicationScope private val applicationScope: CoroutineScope
+) : NetworkMonitor {
+
     private val _isOnline = MutableStateFlow(true)
     override val isOnline: StateFlow<Boolean> = _isOnline.asStateFlow()
+
+    init {
+        applicationScope.launch(ioDispatcher) {
+            while (isActive) {
+                val online = isHostReachable(CHECK_HOST, CHECK_PORT, CONNECT_TIMEOUT_MS)
+                if (online != _isOnline.value) {
+                    logcat(LogPriority.INFO) { "Network connectivity changed: online=$online" }
+                }
+                _isOnline.value = online
+                delay(CHECK_INTERVAL_MS)
+            }
+        }
+    }
+}
+
+internal fun isHostReachable(host: String, port: Int, timeoutMs: Int): Boolean = try {
+    Socket().use { socket -> socket.connect(InetSocketAddress(host, port), timeoutMs) }
+    true
+} catch (e: IOException) {
+    false
 }

--- a/core/storage/src/jvmMain/kotlin/com/grappim/taigamobile/core/storage/platform/AppDataDir.jvm.kt
+++ b/core/storage/src/jvmMain/kotlin/com/grappim/taigamobile/core/storage/platform/AppDataDir.jvm.kt
@@ -8,7 +8,7 @@ private const val APP_DIR_NAME = "TaigaMobile"
  * Per-user, durable application-support directory for the desktop/JVM build — replaces
  * `java.io.tmpdir`, which the OS can clear at any time.
  */
-internal fun appDataDir(): File {
+fun appDataDir(): File {
     val userHome = System.getProperty("user.home")
     val osName = System.getProperty("os.name").lowercase()
     val baseDir = when {

--- a/core/storage/src/jvmMain/kotlin/com/grappim/taigamobile/core/storage/platform/AppDataDir.jvm.kt
+++ b/core/storage/src/jvmMain/kotlin/com/grappim/taigamobile/core/storage/platform/AppDataDir.jvm.kt
@@ -1,0 +1,20 @@
+package com.grappim.taigamobile.core.storage.platform
+
+import java.io.File
+
+private const val APP_DIR_NAME = "TaigaMobile"
+
+/**
+ * Per-user, durable application-support directory for the desktop/JVM build — replaces
+ * `java.io.tmpdir`, which the OS can clear at any time.
+ */
+internal fun appDataDir(): File {
+    val userHome = System.getProperty("user.home")
+    val osName = System.getProperty("os.name").lowercase()
+    val baseDir = when {
+        osName.contains("win") -> File(System.getenv("APPDATA") ?: "$userHome\\AppData\\Roaming")
+        osName.contains("mac") -> File("$userHome/Library/Application Support")
+        else -> File(System.getenv("XDG_DATA_HOME") ?: "$userHome/.local/share")
+    }
+    return File(baseDir, APP_DIR_NAME).apply { mkdirs() }
+}

--- a/core/storage/src/jvmMain/kotlin/com/grappim/taigamobile/core/storage/server/ServerStorageImpl.jvm.kt
+++ b/core/storage/src/jvmMain/kotlin/com/grappim/taigamobile/core/storage/server/ServerStorageImpl.jvm.kt
@@ -2,6 +2,7 @@ package com.grappim.taigamobile.core.storage.server
 
 import com.grappim.taigamobile.core.appinfoapi.AppInfoProvider
 import com.grappim.taigamobile.core.storage.di.createDataStore
+import com.grappim.taigamobile.core.storage.platform.appDataDir
 import org.koin.core.annotation.Single
 import java.io.File
 
@@ -9,7 +10,7 @@ import java.io.File
 class ServerStorageImpl(appInfoProvider: AppInfoProvider) :
     ServerStorage by DataStoreServerStorage(
         dataStore = createDataStore {
-            File(System.getProperty("java.io.tmpdir"), SERVER_STORAGE_FILE_NAME).absolutePath
+            File(appDataDir(), SERVER_STORAGE_FILE_NAME).absolutePath
         },
         appInfoProvider = appInfoProvider
     )

--- a/core/storage/src/jvmTest/kotlin/com/grappim/taigamobile/core/storage/network/NetworkMonitorImplJvmTest.kt
+++ b/core/storage/src/jvmTest/kotlin/com/grappim/taigamobile/core/storage/network/NetworkMonitorImplJvmTest.kt
@@ -1,0 +1,25 @@
+package com.grappim.taigamobile.core.storage.network
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Exercises [isHostReachable] against real sockets — the JVM actual's underlying platform
+ * behaviour, per CLAUDE.md's "prefer the platform whose actual is real" testing convention.
+ * 1.1.1.1:53 is a public, highly-available DNS resolver reachable from any runner with outbound
+ * network access; 192.0.2.1 is RFC 5737 TEST-NET-1, guaranteed non-routable, so the connect
+ * attempt reliably fails rather than depending on a particular local network's failure mode.
+ */
+class NetworkMonitorImplJvmTest {
+
+    @Test
+    fun `isHostReachable returns true for a reachable host`() {
+        assertTrue(isHostReachable(host = "1.1.1.1", port = 53, timeoutMs = 2000))
+    }
+
+    @Test
+    fun `isHostReachable returns false for an unroutable host`() {
+        assertFalse(isHostReachable(host = "192.0.2.1", port = 53, timeoutMs = 1000))
+    }
+}

--- a/docs/desktop/deferred.md
+++ b/docs/desktop/deferred.md
@@ -1,0 +1,19 @@
+# Desktop Linux release: deferred and considered items
+
+**Split out:** 2026-08-09, when [linux-release-plan.md](linux-release-plan.md) closed (tasks 0–9 all
+done, its status table empty). That plan was a sequenced todo list; this doc is not — it's a
+standing record of ideas that were surveyed and intentionally *not* actioned, so they aren't
+silently forgotten and aren't re-proposed from scratch without the context already gathered here.
+
+Nothing below is scoped or started. Pick one up as its own task/plan when there's a concrete reason
+to.
+
+| Idea | Why deferred |
+|---|---|
+| AppImage / Flatpak / Snap | Real additional infrastructure (signing keys, store manifests, Flathub/Snap Store review) — worth it only once the `.deb`/`.rpm`-via-GitHub-Releases path (tasks 0–4) is proven to work end-to-end and there's a concrete reason those aren't enough. |
+| Apt repository (so users get updates via `apt upgrade` instead of re-downloading) | Needs a signing key and hosting; same "prove the simple path first" reasoning as above. |
+| Auto-update mechanism inside the app | Not attempted — no existing infra to build on (see [survey.md](survey.md)); a reasonable follow-up once there's more than one release to update *to*. |
+| arm64 Linux build | jpackage packages for the runner's own architecture only; would need a second CI job on an arm64 runner. Not scoped — revisit if there's actual user demand. |
+| macOS/Windows CI + release wiring | Out of scope for this plan (titled Linux release deliberately) — `Dmg`/`Msi` target formats already exist in the Gradle config and build locally per the survey, but wiring them into CI/release is a separate plan, not folded in here to keep this one small. |
+| Real iOS/Desktop GitHub OAuth implementation | Task 8 only hid the dead button on JVM/iOS (both share the identical no-op `GithubOAuthWebViewDialog` stub) rather than building the real in-app WebView flow — `docs/features/github-auth/plan.md` already lists this out of scope. Bigger than a Linux-release-scoped fix; affects iOS too. |
+| Real JVM offline-transition test in the app's own test suite | Task 9 unit-tests the underlying `isHostReachable` reachability check (both branches, via real sockets) but doesn't drive `NetworkMonitorImpl`'s 5-second polling loop or the UI banner in an automated test — verified live instead (gregory disconnected the machine's real network and confirmed the banner). Automating that would need either a real sleep in the suite or a production seam purely for testing, which CLAUDE.md's "Don't Break Production in Favor of Tests" rule rules out without asking first. |

--- a/docs/desktop/linux-release-plan.md
+++ b/docs/desktop/linux-release-plan.md
@@ -39,9 +39,9 @@ file rather than pushing through.
 | 1 | Move desktop storage off `java.io.tmpdir` | S | ✅ done — 2026-08-09 |
 | 2 | CI job: build the Linux package on PRs | S | ✅ done — 2026-08-09 |
 | 3 | Wire the `.deb` into the release workflow | M | ✅ done — 2026-08-09 |
-| 4 | Add `Rpm` as a second target format | XS | todo |
+| 4 | Add `Rpm` as a second target format | XS | todo ⬅ NEXT |
 | 5 | Install a real logger backend on desktop | S | todo |
-| 6 | Update README once Linux is actually distributed | XS | ⬅ NEXT |
+| 6 | Update README once Linux is actually distributed | XS | ✅ done — 2026-08-09 |
 | 7 | Logout doesn't clear the local DB on desktop | S | ✅ done — 2026-08-09 |
 | 8 | GitHub OAuth login is a dead button on desktop | S | todo (do last) |
 | 9 | Offline detection is a stub on desktop | S | todo (do last) |
@@ -368,6 +368,19 @@ and build locally, per the survey, but nothing in this plan wires them into CI o
 imply they're supported just because `Dmg`/`Msi` appear in the same Gradle block).
 
 **Finalize focus:** low.
+
+**Result (2026-08-09):** Updated `README.md`. Split the platform table's single "Desktop (Linux /
+macOS / Windows)" row into two: `Desktop (Linux)` now reads **Released**, distribution
+[GitHub Releases](https://github.com/Grigoriym/TaigaMobileNova/releases) (`.deb`); `Desktop (macOS /
+Windows)` keeps the old **Builds & runs** / Distribution TBD status, unchanged. Split the "iOS &
+Desktop" prose section the same way: a new "Desktop (Linux)" subsection points at the Releases page,
+while "iOS & Desktop (macOS / Windows)" keeps the original "distribution channels are not yet set up,
+build locally" wording for those three platforms untouched, per the task's explicit instruction not to
+overclaim macOS/Windows support. No other README section touched.
+
+Next: task 4, adding `Rpm` as a second target format — the straight-line release path (0–3, 6, 7) is
+now fully done; 4 is the first remaining `todo` per the status table (5, and the "do last" 8/9, follow
+it).
 
 ---
 

--- a/docs/desktop/linux-release-plan.md
+++ b/docs/desktop/linux-release-plan.md
@@ -1,0 +1,280 @@
+# Desktop Linux release: implementation plan
+
+**Created:** 2026-08-09
+**Baseline:** [survey.md](survey.md) — what the desktop target looks like before this plan started.
+
+A sequence of small, independent tasks. Each one is sized to fit in a **single clean context**: a
+session picks exactly one task, does it, runs `finalize`, and stops. Nothing here requires holding
+two tasks in your head at once.
+
+## How to run a task
+
+1. Read the status table below and take the task marked **NEXT**. (If none is marked, take the first
+   `todo`.) Never take a `deferred`/gated task without asking — check the table row and the task's own
+   heading for a gate before starting.
+   **Before assuming the NEXT task is actually undone, run `git status`/`git diff`.** A session can
+   finish the code and even the task's own Result note, then get cut off before the status-table
+   update, `finalize`, and commit — treat matching uncommitted changes as a finished task waiting on
+   bookkeeping, not as a task to redo.
+2. Read only that task's section, plus [survey.md](survey.md) if you need the wider picture.
+3. Do it. Verify with the task's own `Done when` commands — not by eyeballing.
+4. **Update the status table**: set this task to `✅ done — <date>`, move `⬅ NEXT` to the task that
+   follows. Add a `**Result (<date>):**` note to the task's own section saying what actually
+   happened — especially anything that differed from the description. **End the Result note by naming
+   what comes next** — the next task number and name, or "queue is empty" if nothing is scoped. Say
+   this in prose; gregory reads the Result note, not the table, to tell whether there's more to do.
+5. Run the **`finalize` skill**. Each task lists a *Finalize focus* hint.
+6. **Commit and push** — same standing rule as `docs/testing/improvement-plan.md`: don't ask, don't
+   stop after finalize waiting to be told. Never commit a red build, never push to `dev` directly for
+   these changes (open a PR the normal way if that's this repo's flow for `dev`), ask before anything
+   beyond commit+push.
+
+**Do not batch tasks.** If a task turns out bigger than described, split it further and update this
+file rather than pushing through.
+
+## Status
+
+| # | Task | Size | Status |
+|---|---|---|---|
+| 0 | Fix the broken icon path | XS | ⬅ NEXT |
+| 1 | Move desktop storage off `java.io.tmpdir` | S | todo |
+| 2 | CI job: build the Linux package on PRs | S | todo |
+| 3 | Wire the `.deb` into the release workflow | M | todo |
+| 4 | Add `Rpm` as a second target format | XS | deferred — ask first |
+| 5 | Install a real logger backend on desktop | S | deferred — ask first |
+| 6 | Update README once Linux is actually distributed | XS | todo (do last, after 3) |
+
+Sizes: XS = minutes, S = under an hour, M = a focused session.
+
+**Scope decision (2026-08-09):** tasks 0–3 and 6 are the straight-line path to "a Linux `.deb` a
+user can actually download and run correctly" and are in scope to work straight through. Tasks 4–5
+are real improvements but not required for a first release — **gated on asking first**, same
+convention `docs/testing/improvement-plan.md` uses for its own gated items. Task 6 depends on 3
+landing (no point documenting a distribution channel that doesn't exist yet) but is otherwise trivial
+and does not need to wait for 4–5.
+
+Task ordering rationale: 0 unblocks everything else (nothing downstream can be verified against a
+build that doesn't produce a package). 1 is the correctness bug that matters most to a real user and
+has no dependency on 0 having landed, but is listed second because it's less urgent than *nothing
+packages at all*. 2 depends on 0 (the CI job would fail on the same icon bug) and should land before
+3 (proving the package builds in CI before wiring it into a release is cheaper to debug). 3 depends
+on 0–2.
+
+---
+
+## Task 0 — Fix the broken icon path
+
+**Why:** `composeApp/build.gradle.kts`'s `nativeDistributions` block points all three platforms'
+`iconFile` at `../info/art/...`; the real directory is `../art/...` (no `info/`). Confirmed by
+actually running `./gradlew :composeApp:packageDistributionForCurrentOS`, which fails
+`:composeApp:packageDeb` on Gradle's task-input validation (`Input file does not exist`). See
+[survey.md](survey.md#packaging-config) for the full command output and the `git log -S` that traces
+the bug back to `0d4f8ccf` (PR #221) — it has never worked.
+
+**Scope:** three one-line edits in `composeApp/build.gradle.kts`:
+```kotlin
+linux { iconFile.set(project.file("../art/taiga-mobile-logo.png")) }
+windows { iconFile.set(project.file("../art/taiga-mobile-logo.ico")) }
+macOS { iconFile.set(project.file("../art/taiga-mobile-logo.icns")) }
+```
+Nothing else in the file changes. Don't touch `packageDeb`/`packageDmg`/`packageMsi` task
+configuration beyond the icon path — this is a path fix, not a packaging redesign.
+
+**Done when:** `./gradlew :composeApp:packageDistributionForCurrentOS` completes successfully and
+produces a `.deb` under `composeApp/build/compose/binaries/main/deb/`. Actually run it — this is the
+exact command the survey used to prove the bug; use it to prove the fix, don't just eyeball the diff.
+
+**Finalize focus:** low — this is a pure bug fix with an obvious verification command. Worth noting
+in the finalize pass only if the produced `.deb` has anything else visibly wrong (bad icon rendering,
+wrong menu category) since this task is the first time anyone has looked at the output at all.
+
+---
+
+## Task 1 — Move desktop storage off `java.io.tmpdir`
+
+**Why:** every JVM-actual persistent store (Room DB, four DataStores, server URL) resolves its file
+path under `java.io.tmpdir`, which is not durable on Linux — see
+[survey.md](survey.md#storage--the-bigger-problem) for the full table and reasoning. A shipped build
+would lose logins and local data unpredictably. The iOS actuals already show the right shape
+(`NSDocumentDirectory`); this task gives the JVM actuals the equivalent.
+
+**Files to change** (all `src/jvmMain`, none of this touches `jvmTest` — the test-only use of
+`java.io.tmpdir` in `:testing/.../PlatformTestUtils.kt` and
+`composeApp/src/jvmTest/.../LiveTaigaSession.kt` is correct and out of scope):
+
+- `core/storage/src/jvmMain/kotlin/com/grappim/taigamobile/core/storage/di/DBModule.jvm.kt`
+- `core/storage/src/jvmMain/kotlin/com/grappim/taigamobile/core/storage/di/StorageModule.jvm.kt`
+  (four `create*DataStore` functions)
+- `core/storage/src/jvmMain/kotlin/com/grappim/taigamobile/core/storage/server/ServerStorageImpl.jvm.kt`
+
+**Approach:** resolve a per-user application-support directory instead of the temp dir. The standard
+JVM-only way (no extra dependency) is the platform-appropriate env var / system property:
+- Linux: `${XDG_DATA_HOME:-~/.local/share}/TaigaMobile`
+- macOS (if ever exercised via this same JVM code path — desktop is currently only being shipped for
+  Linux, but the JVM actual is shared): `~/Library/Application Support/TaigaMobile`
+- Windows: `%APPDATA%\TaigaMobile`
+
+Write one small internal helper (e.g. `appDataDir(): File` in `core/storage`'s `jvmMain`) that picks
+the right base dir per `os.name`, creates it if missing (`File.mkdirs()`), and returns it — then point
+all six file-producing lambdas at `File(appDataDir(), <existing file name constant>).absolutePath`
+instead of `File(System.getProperty("java.io.tmpdir"), ...)`. Keep the existing file name constants
+(`AUTH_DATA_STORE_FILE_NAME` etc.) unchanged — only the base directory moves.
+
+Since the goal stated to the user is Linux specifically, it's fine to implement only the Linux branch
+correctly and use a sane same-shape fallback for the other two `os.name` cases rather than researching
+macOS/Windows conventions in depth — note in the Result note which branches were verified vs.
+best-effort.
+
+**Migration note:** no migration path is needed. Nothing has ever been packaged and shipped, so there
+is no existing user data anywhere to preserve — this is closing a bug in unreleased code, not a schema
+migration.
+
+**Done when:** running `./gradlew :composeApp:run`, logging in, closing the app, and re-running
+`:composeApp:run` shows the session is still active (no re-login prompt) — the concrete behavior the
+bug currently breaks. Also confirm the new files land where expected
+(`ls ~/.local/share/TaigaMobile/` after a run, on Linux). `./gradlew jvmTest` must stay green — the
+existing `jvmTest`/integration tests use their own `java.io.tmpdir`-based paths (`PlatformTestUtils.kt`,
+`LiveTaigaSession.kt`) and must be unaffected by this change since production and test code use
+different helpers.
+
+**Finalize focus:** high — this is the one change in the whole plan most likely to reveal a detail
+nobody has thought about yet (e.g. does `PreferenceDataStoreFactory.createWithPath`'s underlying
+implementation handle a directory that doesn't exist yet, or does `mkdirs()` need to happen before
+each `create*DataStore` call, not just once at startup). Say plainly what was and wasn't verified.
+
+---
+
+## Task 2 — CI job: build the Linux package on PRs
+
+**Why:** nothing in CI has ever run `packageDistributionForCurrentOS`/`packageDeb` — that's exactly
+how task 0's bug went unnoticed since PR #221. Without this, a future regression (e.g. someone moves
+`art/` again) goes uncaught the same way.
+
+**Depends on task 0** (the job would fail on the same bug otherwise) and ideally task 1 (no strict
+build dependency, but there's little point guarding packaging in CI while the packaged app still has
+the storage bug — check the status table; if 1 isn't done yet, this task can still proceed since it
+only needs the package to *build*, not to be correct).
+
+**Scope:** add a `desktop-package` job to `.github/workflows/build.yml` (same PR-gate workflow the
+Android job lives in), running on `ubuntu-latest`:
+- Java 21 setup — reuse `./.github/actions/android-setup-composite-action` for consistency with the
+  rest of the repo's CI (it also sets up the Android SDK, which this job doesn't need, but keeping one
+  setup action avoids maintaining two). If that overhead turns out to matter, a lighter Java-only
+  `actions/setup-java` step is the alternative — note which was chosen and why in the Result note.
+- `sudo apt-get update && sudo apt-get install -y fakeroot` before the package step — per
+  [survey.md](survey.md#toolchain--ci-environment-notes), `fakeroot` is not confirmed present on
+  `ubuntu-latest`; confirm one way or the other in this task rather than finding out from a red CI run.
+- `./gradlew :composeApp:packageDeb` (not the full `packageDistributionForCurrentOS`, which would also
+  attempt Dmg/Msi — those need macOS/Windows runners and are out of scope for a Linux-only CI check).
+- No artifact upload needed for this task — that's task 3's job. This task only needs the build to
+  succeed as a PR gate.
+
+**Done when:** a PR touching `composeApp/build.gradle.kts` (e.g. this very task's own diff, or a
+throwaway change) shows the new job passing in the Actions tab, and reverting task 0's fix locally and
+re-running the job locally (`act` or just running the Gradle command by hand) confirms it would have
+caught that regression.
+
+**Finalize focus:** medium — note whether `fakeroot` needed the explicit install step or was already
+present, since that's exactly the kind of CI-environment fact that's expensive to rediscover later.
+
+---
+
+## Task 3 — Wire the `.deb` into the release workflow
+
+**Why:** this is the actual "release" — everything before this is prerequisite plumbing. Right now
+`release.yml` only builds and uploads Android artifacts.
+
+**Depends on tasks 0–2.**
+
+**Scope:** extend `.github/workflows/release.yml`'s existing `release` job (same tag-triggered /
+`workflow_dispatch` job that already builds the Android artifacts) rather than adding a second job —
+keeps the single GitHub Release created by `softprops/action-gh-release@v3` getting all platforms'
+assets in one step, matching how the Android APKs/AAB are already listed together in one `files:`
+block:
+- Add the same Java 21 + `fakeroot` setup task 2 settled on.
+- `./gradlew :composeApp:packageDeb`.
+- Add the produced `.deb` (path under `composeApp/build/compose/binaries/main/deb/*.deb`) to the
+  existing `files:` list in the `Create GitHub release` step, alongside the APK/AAB paths.
+
+**Open question to resolve while scoping this task, not before:** does the `.deb`'s embedded version
+need to track `libs.versions.toml`'s `version-name`/`version-code` the same way the Android artifacts
+do? (It already does — `packageVersion`/`debPackageVersion` are wired from `libs.versions.toml` per
+the survey — so this is likely a non-issue, but confirm the built `.deb`'s actual version string
+matches the release tag before calling this done.)
+
+**Done when:** a `workflow_dispatch` run of `release.yml` (the documented way to re-run a release
+build without cutting a new tag, per `docs/build/release.md`'s troubleshooting section) produces a
+GitHub Release with the `.deb` attached alongside the Android artifacts, and `dpkg -I` on the
+downloaded file shows the right version/package name.
+
+**Finalize focus:** medium — this is mostly mechanical once tasks 0–2 are done; note anything about
+GitHub Release asset naming collisions or `action-gh-release`'s glob behavior that wasn't obvious from
+the existing Android `files:` block.
+
+---
+
+## Task 4 — Add `Rpm` as a second target format
+
+⛔ **Gated — do not start without asking (see status table).** Real value (Fedora/openSUSE users) but
+not required for a first release; asking first avoids scope creep on top of an already multi-task plan.
+
+**Why, if approved:** `targetFormats` currently only includes `Deb`. jpackage supports `Rpm` as a
+sibling format with the same `nativeDistributions` config — no architecture beyond what task 0–3
+already built.
+
+**Scope, if approved:** add `TargetFormat.Rpm` to `targetFormats(...)` in
+`composeApp/build.gradle.kts`, confirm `rpmbuild` availability on the CI image (likely needs an
+explicit `apt-get install rpm` on an `ubuntu-latest` runner — verify, don't assume, same as task 2 did
+for `fakeroot`), extend the CI job from task 2 and the release wiring from task 3 to also build/upload
+`packageRpm`.
+
+**Done when:** `./gradlew :composeApp:packageRpm` succeeds locally and in CI, and the `.rpm` is
+attached to the GitHub Release next to the `.deb`.
+
+---
+
+## Task 5 — Install a real logger backend on desktop
+
+⛔ **Gated — do not start without asking (see status table).** Genuinely useful for diagnosing
+user-reported bugs post-release, but not required to ship a first release, and the right design (file
+location, rotation, whether to also wire `CrashReporterImpl.jvm.kt` at the same time) deserves a scope
+discussion rather than being assumed here.
+
+**Why, if approved:** `TaigaMobileDesktop.kt` never calls `TaigaLogger.install(...)`; Desktop/JVM
+falls back to the no-op `NoLog` backend (per CLAUDE.md's Logging table and
+[survey.md](survey.md#diagnosability-on-desktop-existing-documented-gaps--not-new-findings)). Every
+`logcat {}` call site is silently dropped, so a Linux user's bug report comes with zero log context.
+
+**Scope, if approved:** a `core/logger` JVM backend that writes to a file (natural location: the same
+per-user app-data directory task 1 introduces), installed from `TaigaMobileDesktop.kt`'s `main()`
+alongside the existing `FileKit.init(...)`/`startKoin(...)` calls. Rotation/size-capping policy and
+whether `CrashReporterImpl.jvm.kt` should also stop being a pure stub are open questions to resolve
+when this task is actually scoped, not decided here.
+
+---
+
+## Task 6 — Update README once Linux is actually distributed
+
+**Depends on task 3.** Trivial once 3 lands: change README's desktop row from
+`Distribution TBD` to say where the `.deb` is (GitHub Releases), and update the "iOS & Desktop" section
+that currently tells readers "distribution channels are not yet set up" for the Linux case
+specifically — leave the iOS/macOS/Windows wording alone since this plan doesn't touch those.
+
+**Done when:** README accurately describes how a Linux user gets the app, and doesn't overclaim
+anything about macOS/Windows that tasks 0–3 didn't actually do (those `targetFormats` entries exist
+and build locally, per the survey, but nothing in this plan wires them into CI or a release — don't
+imply they're supported just because `Dmg`/`Msi` appear in the same Gradle block).
+
+**Finalize focus:** low.
+
+---
+
+## Considered and deferred
+
+| Idea | Why deferred |
+|---|---|
+| AppImage / Flatpak / Snap | Real additional infrastructure (signing keys, store manifests, Flathub/Snap Store review) — worth it only once the `.deb`-via-GitHub-Releases path (tasks 0–3) is proven to work end-to-end and there's a concrete reason `.deb`-only isn't enough. |
+| Apt repository (so users get updates via `apt upgrade` instead of re-downloading) | Needs a signing key and hosting; same "prove the simple path first" reasoning as above. |
+| Auto-update mechanism inside the app | Not attempted — no existing infra to build on (see survey); a reasonable follow-up once there's more than one release to update *to*. |
+| arm64 Linux build | jpackage packages for the runner's own architecture only; would need a second CI job on an arm64 runner. Not scoped — revisit if there's actual user demand. |
+| macOS/Windows CI + release wiring | Out of scope for this plan (titled Linux release deliberately) — `Dmg`/`Msi` target formats already exist in the Gradle config and build locally per the survey, but wiring them into CI/release is a separate plan, not folded in here to keep this one small. |

--- a/docs/desktop/linux-release-plan.md
+++ b/docs/desktop/linux-release-plan.md
@@ -39,7 +39,7 @@ file rather than pushing through.
 | 0 | Fix the broken icon path | XS | ✅ done — 2026-08-09 |
 | 1 | Move desktop storage off `java.io.tmpdir` | S | ✅ done — 2026-08-09 |
 | 2 | CI job: build the Linux package on PRs | S | ✅ done — 2026-08-09 |
-| 3 | Wire the `.deb` into the release workflow | M | ⬅ NEXT |
+| 3 | Wire the `.deb` into the release workflow | M | ✅ done — 2026-08-09 |
 | 4 | Add `Rpm` as a second target format | XS | deferred — ask first |
 | 5 | Install a real logger backend on desktop | S | deferred — ask first |
 | 6 | Update README once Linux is actually distributed | XS | todo (do last, after 3) |
@@ -274,7 +274,32 @@ downloaded file shows the right version/package name.
 GitHub Release asset naming collisions or `action-gh-release`'s glob behavior that wasn't obvious from
 the existing Android `files:` block.
 
----
+**Result (2026-08-09):** Extended the existing `release` job in `.github/workflows/release.yml`
+rather than adding a second job, exactly as scoped: a `Package Linux deb` step
+(`./gradlew :composeApp:packageDeb`) plus the same `fakeroot` install step task 2 settled on
+(confirmed already present on `ubuntu-latest`, so it's a no-op safety net there too), inserted after
+the Android build steps and before `Upload Release Build To Artifacts`. Added
+`composeApp/build/compose/binaries/main/deb/*.deb` to both the artifact-upload `path:` block and the
+`Create GitHub release` step's `files:` block, alongside the existing APK/AAB paths — no naming
+collisions, `action-gh-release`'s glob just picks up the single `.deb` the same way it picks up the
+Android outputs.
+
+**Open question resolved:** yes, the `.deb`'s version tracks `libs.versions.toml` correctly and needs
+no extra wiring. Ran `./gradlew :composeApp:packageDeb` locally and confirmed via `dpkg -I` — `Version:
+2.1.5`, matching `version-name` in `gradle/libs.versions.toml` and the current `v2.1.5` tag.
+
+**What was and wasn't verified:** the YAML was validated for syntax (parsed successfully with
+PyYAML) and the step ordering/names checked. `./gradlew :composeApp:packageDeb` was run locally, not
+in the `release.yml` context. **The actual `workflow_dispatch` run against the live release was
+deliberately not triggered** — it would have modified the real, public `v2.1.5` GitHub Release
+(adding an asset and, via `generate_release_notes: true`, potentially touching release notes users
+may already be looking at). Asked gregory first; the call was to skip the live run and rely on local
+verification plus the CI `desktop-package` job (task 2), which already proves `packageDeb` builds
+successfully in the same CI environment this job now uses. Full end-to-end confirmation (a real
+`workflow_dispatch` or tag-triggered run actually attaching a working `.deb` to a GitHub Release) is
+deferred to the next real release cut — flagged here rather than silently assumed.
+
+Next: task 6, updating the README now that task 3 has landed (tasks 4–5 stay gated on asking).
 
 ## Task 4 — Add `Rpm` as a second target format
 

--- a/docs/desktop/linux-release-plan.md
+++ b/docs/desktop/linux-release-plan.md
@@ -37,8 +37,8 @@ file rather than pushing through.
 | # | Task | Size | Status |
 |---|---|---|---|
 | 0 | Fix the broken icon path | XS | ✅ done — 2026-08-09 |
-| 1 | Move desktop storage off `java.io.tmpdir` | S | ⬅ NEXT |
-| 2 | CI job: build the Linux package on PRs | S | todo |
+| 1 | Move desktop storage off `java.io.tmpdir` | S | ✅ done — 2026-08-09 |
+| 2 | CI job: build the Linux package on PRs | S | ⬅ NEXT |
 | 3 | Wire the `.deb` into the release workflow | M | todo |
 | 4 | Add `Rpm` as a second target format | XS | deferred — ask first |
 | 5 | Install a real logger backend on desktop | S | deferred — ask first |
@@ -149,6 +149,36 @@ different helpers.
 nobody has thought about yet (e.g. does `PreferenceDataStoreFactory.createWithPath`'s underlying
 implementation handle a directory that doesn't exist yet, or does `mkdirs()` need to happen before
 each `create*DataStore` call, not just once at startup). Say plainly what was and wasn't verified.
+
+**Result (2026-08-09):** Implemented exactly as scoped — one new internal helper,
+`appDataDir(): File` in `core/storage/src/jvmMain/.../platform/AppDataDir.jvm.kt`, picking
+`$XDG_DATA_HOME/TaigaMobile` (falling back to `~/.local/share/TaigaMobile`) on Linux, with
+same-shape best-effort branches for macOS (`~/Library/Application Support/TaigaMobile`) and Windows
+(`%APPDATA%\TaigaMobile`) as the task allowed. All six `File(System.getProperty("java.io.tmpdir"),
+...)` call sites in `DBModule.jvm.kt`, `StorageModule.jvm.kt` (four `create*DataStore` functions) and
+`ServerStorageImpl.jvm.kt` now go through `appDataDir()`; file name constants untouched.
+`mkdirs()` happens once inside `appDataDir()` itself (every caller invokes it fresh), so the
+"does `mkdirs()` need to happen before each call" question the task flagged doesn't arise — it always
+does.
+
+**Verified end-to-end, not just compiled.** With no `xdotool`/`ydotool` available initially, gregory
+installed `xdotool` and gave the go-ahead to drive the real GUI. Ran `:composeApp:run` against
+gregory's local dev Taiga instance, logged in via simulated keyboard/mouse input
+(`docs/local-info.md` / project memory: `admin`/`admin`) and confirmed all six files land under
+`~/.local/share/TaigaMobile/` (`taigamobilenova.db(+.lck/-wal/-shm)`, `auth_storage.preferences_pb`,
+`taiga_session_storage.preferences_pb`, `taiga_server_storage_name.preferences_pb`). Selected a
+project to reach the Dashboard, closed the window, confirmed the process fully exited, then launched
+a **second, independent** `:composeApp:run` process — it opened directly on the Dashboard with no
+re-login prompt, confirming the session persists exactly as the bug fix intends. Only the Linux
+branch was exercised at runtime; macOS/Windows branches are unverified best-effort, as scoped.
+`./gradlew jvmTest` and `ktlintCheck` both green across the whole repo afterward.
+
+**Found and deliberately not fixed:** the login screen's server-URL validation regex rejects a bare
+`localhost` hostname (requires a dotted FQDN), so testing needed `http://127.0.0.1:9000` instead of
+`http://localhost:9000` — pre-existing, unrelated to this task's diff. Logged as
+[docs/revisit.md #29](../revisit.md#29-login-screens-server-url-regex-rejects-bare-localhost).
+
+Next: task 2, the CI job that builds the Linux package on PRs.
 
 ---
 

--- a/docs/desktop/linux-release-plan.md
+++ b/docs/desktop/linux-release-plan.md
@@ -39,8 +39,8 @@ file rather than pushing through.
 | 1 | Move desktop storage off `java.io.tmpdir` | S | ✅ done — 2026-08-09 |
 | 2 | CI job: build the Linux package on PRs | S | ✅ done — 2026-08-09 |
 | 3 | Wire the `.deb` into the release workflow | M | ✅ done — 2026-08-09 |
-| 4 | Add `Rpm` as a second target format | XS | todo ⬅ NEXT |
-| 5 | Install a real logger backend on desktop | S | todo |
+| 4 | Add `Rpm` as a second target format | XS | ✅ done — 2026-08-09 |
+| 5 | Install a real logger backend on desktop | S | todo ⬅ NEXT |
 | 6 | Update README once Linux is actually distributed | XS | ✅ done — 2026-08-09 |
 | 7 | Logout doesn't clear the local DB on desktop | S | ✅ done — 2026-08-09 |
 | 8 | GitHub OAuth login is a dead button on desktop | S | todo (do last) |
@@ -332,6 +332,41 @@ for `fakeroot`), extend the CI job from task 2 and the release wiring from task 
 
 **Done when:** `./gradlew :composeApp:packageRpm` succeeds locally and in CI, and the `.rpm` is
 attached to the GitHub Release next to the `.deb`.
+
+**Result (2026-08-09):** Added `TargetFormat.Rpm` to `targetFormats(...)` in
+`composeApp/build.gradle.kts` — one line, no other `nativeDistributions` config touched. Checked the
+Compose Multiplatform plugin's own source (`PlatformSettings.kt`/`packageVersions.kt`, available
+locally at `~/proj/kmp/compose-multiplatform`) before assuming version wiring needed extra work:
+`rpmPackageVersion` exists as a format-specific override but falls back to the shared
+`packageVersion` (already set from `libs.versions.version.name`) when unset, exactly like
+`debPackageVersion` already does for Deb — so no version wiring was needed beyond the one-line format
+addition.
+
+**`rpmbuild` was not present locally or (unconfirmed until this task) on `ubuntu-latest`** — unlike
+`fakeroot` (task 2 found already installed), the `rpm` package genuinely needed the explicit
+`apt-get install`. Gregory installed it locally (sudo declined for the assistant, installed by
+gregory directly) so `./gradlew :composeApp:packageRpm` could be run and verified locally first:
+succeeded, producing `taigamobile-2.1.5-1.x86_64.rpm`; `rpm -qip` confirmed sane metadata (name,
+version `2.1.5` matching `libs.versions.toml`, summary/description). Extended both
+`.github/workflows/build.yml`'s `desktop-package` job and `.github/workflows/release.yml`'s `release`
+job: `Install fakeroot` steps became `Install fakeroot and rpm` (added `rpm` to the same apt-get
+call), and a `Package Linux rpm` step (`./gradlew :composeApp:packageRpm`) was added right after the
+existing `Package Linux deb` step in both files. `release.yml`'s artifact-upload `path:` and the
+`Create GitHub release` `files:` block both got `composeApp/build/compose/binaries/main/rpm/*.rpm`
+alongside the existing `*.deb` entry.
+
+**Verified both `Done when` conditions, not just "looks right":** local `packageRpm` run (above), plus
+pushed to the already-open PR #345 and watched the `desktop-package` job via `gh run watch` — both
+`Package Linux deb` and `Package Linux rpm` steps passed on the real `ubuntu-latest` image, confirming
+the explicit `rpm` install step is load-bearing there too (not a no-op safety net like `fakeroot`
+turned out to be in task 2). **Not verified**: an actual `workflow_dispatch`/tag-triggered run of
+`release.yml` attaching the `.rpm` to a real GitHub Release — same deliberate deferral task 3 made for
+the `.deb`, for the same reason (avoids touching the live `v2.1.5` release); relies on the CI job
+above proving `packageRpm` builds in the same environment `release.yml` now uses. `./gradlew
+jvmTest` and `ktlintCheck` both green across the whole repo (Gradle-script-only change; no Kotlin
+source touched).
+
+Next: task 5, installing a real logger backend on desktop.
 
 ---
 

--- a/docs/desktop/linux-release-plan.md
+++ b/docs/desktop/linux-release-plan.md
@@ -10,8 +10,7 @@ two tasks in your head at once.
 ## How to run a task
 
 1. Read the status table below and take the task marked **NEXT**. (If none is marked, take the first
-   `todo`.) Never take a `deferred`/gated task without asking — check the table row and the task's own
-   heading for a gate before starting.
+   `todo`, respecting any explicit ordering note like "do last".)
    **Before assuming the NEXT task is actually undone, run `git status`/`git diff`.** A session can
    finish the code and even the task's own Result note, then get cut off before the status-table
    update, `finalize`, and commit — treat matching uncommitted changes as a finished task waiting on
@@ -40,22 +39,21 @@ file rather than pushing through.
 | 1 | Move desktop storage off `java.io.tmpdir` | S | ✅ done — 2026-08-09 |
 | 2 | CI job: build the Linux package on PRs | S | ✅ done — 2026-08-09 |
 | 3 | Wire the `.deb` into the release workflow | M | ✅ done — 2026-08-09 |
-| 4 | Add `Rpm` as a second target format | XS | deferred — ask first |
-| 5 | Install a real logger backend on desktop | S | deferred — ask first |
+| 4 | Add `Rpm` as a second target format | XS | todo |
+| 5 | Install a real logger backend on desktop | S | todo |
 | 6 | Update README once Linux is actually distributed | XS | todo (do last, after 3 and 7) |
 | 7 | Logout doesn't clear the local DB on desktop | S | ⬅ NEXT |
-| 8 | GitHub OAuth login is a dead button on desktop | S | deferred — ask first, do last |
-| 9 | Offline detection is a stub on desktop | S | deferred — ask first, do last |
+| 8 | GitHub OAuth login is a dead button on desktop | S | todo (do last) |
+| 9 | Offline detection is a stub on desktop | S | todo (do last) |
 
 Sizes: XS = minutes, S = under an hour, M = a focused session.
 
 **Scope decision (2026-08-09):** tasks 0–3, 6, and 7 are the straight-line path to "a Linux `.deb` a
 user can actually download and run correctly" and are in scope to work straight through. Tasks 4–5
-are real improvements but not required for a first release — **gated on asking first**, same
-convention `docs/testing/improvement-plan.md` uses for its own gated items. Task 6 depends on 3
-landing (no point documenting a distribution channel that doesn't exist yet) and now also on 7 (no
-point calling the release straight-line-done while a known data bug sits unfixed) but is otherwise
-trivial and does not need to wait for 4–5.
+are real improvements but not required for a first release. Task 6 depends on 3 landing (no point
+documenting a distribution channel that doesn't exist yet) and now also on 7 (no point calling the
+release straight-line-done while a known data bug sits unfixed) but is otherwise trivial and does not
+need to wait for 4–5.
 
 Task ordering rationale: 0 unblocks everything else (nothing downstream can be verified against a
 build that doesn't produce a package). 1 is the correctness bug that matters most to a real user and
@@ -68,9 +66,14 @@ on 0–2.
 gets the same short shrift as iOS) turned up three real JVM-actual gaps beyond the original three the
 survey found. Task 7 is in scope now because it's a plain data-correctness bug in the same family as
 task 1 (a JVM actual silently doing nothing where Android's does real work) and is cheap. Tasks 8 and
-9 are real but explicitly **deferred to last, per gregory (2026-08-09)** — both also affect iOS, not
-just desktop, which makes them bigger than a Linux-release-scoped fix, and neither blocks a user from
-successfully installing and using a first `.deb` release the way tasks 0–3 and 7 do.
+9 are real but ordered **last, per gregory (2026-08-09)** — both also affect iOS, not just desktop,
+which makes them bigger than a Linux-release-scoped fix, and neither blocks a user from successfully
+installing and using a first `.deb` release the way tasks 0–3 and 7 do.
+
+**No task in this plan is ask-first-gated anymore (removed 2026-08-09, per gregory)** — the earlier
+convention (borrowed from `docs/testing/improvement-plan.md`) required explicit approval before
+starting tasks 4, 5, 8, and 9. That requirement is gone; the tasks themselves, their scope, and their
+ordering (4–5 and 8–9 come after the straight-line path 0–3/6/7, 8–9 specifically last) are unchanged.
 
 ---
 
@@ -311,18 +314,17 @@ successfully in the same CI environment this job now uses. Full end-to-end confi
 `workflow_dispatch` or tag-triggered run actually attaching a working `.deb` to a GitHub Release) is
 deferred to the next real release cut — flagged here rather than silently assumed.
 
-Next: task 6, updating the README now that task 3 has landed (tasks 4–5 stay gated on asking).
+Next: task 6, updating the README now that task 3 has landed.
 
 ## Task 4 — Add `Rpm` as a second target format
 
-⛔ **Gated — do not start without asking (see status table).** Real value (Fedora/openSUSE users) but
-not required for a first release; asking first avoids scope creep on top of an already multi-task plan.
+Real value (Fedora/openSUSE users) but not required for a first release.
 
-**Why, if approved:** `targetFormats` currently only includes `Deb`. jpackage supports `Rpm` as a
+**Why:** `targetFormats` currently only includes `Deb`. jpackage supports `Rpm` as a
 sibling format with the same `nativeDistributions` config — no architecture beyond what task 0–3
 already built.
 
-**Scope, if approved:** add `TargetFormat.Rpm` to `targetFormats(...)` in
+**Scope:** add `TargetFormat.Rpm` to `targetFormats(...)` in
 `composeApp/build.gradle.kts`, confirm `rpmbuild` availability on the CI image (likely needs an
 explicit `apt-get install rpm` on an `ubuntu-latest` runner — verify, don't assume, same as task 2 did
 for `fakeroot`), extend the CI job from task 2 and the release wiring from task 3 to also build/upload
@@ -335,21 +337,21 @@ attached to the GitHub Release next to the `.deb`.
 
 ## Task 5 — Install a real logger backend on desktop
 
-⛔ **Gated — do not start without asking (see status table).** Genuinely useful for diagnosing
-user-reported bugs post-release, but not required to ship a first release, and the right design (file
-location, rotation, whether to also wire `CrashReporterImpl.jvm.kt` at the same time) deserves a scope
-discussion rather than being assumed here.
+Genuinely useful for diagnosing user-reported bugs post-release, but not required to ship a first
+release, and the right design (file location, rotation, whether to also wire
+`CrashReporterImpl.jvm.kt` at the same time) deserves a scope pass before starting rather than being
+assumed here.
 
-**Why, if approved:** `TaigaMobileDesktop.kt` never calls `TaigaLogger.install(...)`; Desktop/JVM
+**Why:** `TaigaMobileDesktop.kt` never calls `TaigaLogger.install(...)`; Desktop/JVM
 falls back to the no-op `NoLog` backend (per CLAUDE.md's Logging table and
 [survey.md](survey.md#diagnosability-on-desktop-existing-documented-gaps--not-new-findings)). Every
 `logcat {}` call site is silently dropped, so a Linux user's bug report comes with zero log context.
 
-**Scope, if approved:** a `core/logger` JVM backend that writes to a file (natural location: the same
+**Scope:** a `core/logger` JVM backend that writes to a file (natural location: the same
 per-user app-data directory task 1 introduces), installed from `TaigaMobileDesktop.kt`'s `main()`
 alongside the existing `FileKit.init(...)`/`startKoin(...)` calls. Rotation/size-capping policy and
 whether `CrashReporterImpl.jvm.kt` should also stop being a pure stub are open questions to resolve
-when this task is actually scoped, not decided here.
+when this task is actually started, not decided here.
 
 ---
 
@@ -403,9 +405,9 @@ that Android's one-liner didn't make obvious was needed.
 
 ## Task 8 — GitHub OAuth login is a dead button on desktop
 
-⛔ **Gated — do not start without asking (see status table). Deferred to last per gregory (2026-08-09).**
+**Ordered last, per gregory (2026-08-09)** (see status table).
 
-**Why, if approved:** `LoginScreen.kt` wires the "Continue with GitHub" button unconditionally on all
+**Why:** `LoginScreen.kt` wires the "Continue with GitHub" button unconditionally on all
 platforms. `LoginViewModel.startGithubOAuth()` succeeds (fetches the OAuth client ID) and fires an
 event that opens `GithubOAuthWebViewDialog` — a real in-app WebView flow on Android
 (`GithubOAuthWebViewDialog.android.kt`), but on JVM (`feature/login/ui/src/jvmMain/kotlin/com/grappim/taigamobile/feature/login/ui/GithubOAuthWebViewDialog.jvm.kt`)
@@ -420,7 +422,7 @@ stub), not silently swallow the click.
 plan; and it doesn't block a user from installing and using a first `.deb` release, since the rest of
 login (username/password, presumably) works normally.
 
-**Scope, if approved:** hide or disable the GitHub button on platforms where
+**Scope:** hide or disable the GitHub button on platforms where
 `GithubOAuthWebViewDialog` is a no-op, rather than implementing the actual WebView flow for JVM/iOS
 (that would be a much bigger task and isn't what's being asked here — confirm scope again before
 starting, since "hide the button" and "implement OAuth for desktop" are very different sizes).
@@ -429,9 +431,9 @@ starting, since "hide the button" and "implement OAuth for desktop" are very dif
 
 ## Task 9 — Offline detection is a stub on desktop
 
-⛔ **Gated — do not start without asking (see status table). Deferred to last per gregory (2026-08-09).**
+**Ordered last, per gregory (2026-08-09)** (see status table).
 
-**Why, if approved:** `LocalOfflineState` (`uikit`) is driven by `MainViewModel.isOffline`, which
+**Why:** `LocalOfflineState` (`uikit`) is driven by `MainViewModel.isOffline`, which
 reads `NetworkMonitor.isOnline`. `NetworkMonitorImpl` has three implementations, all in
 `core/storage/src/*/kotlin/com/grappim/taigamobile/core/storage/network/`: Android's
 (`androidMain/.../NetworkMonitorImpl.kt`) really registers a `ConnectivityManager.NetworkCallback`;
@@ -441,14 +443,14 @@ reported identical by the auditing pass, not independently re-verified here). De
 reports online: the offline banner never shows, and no write action is ever disabled for connectivity
 reasons on those two platforms, contrary to CLAUDE.md's documented offline-state convention.
 
-**Why deferred:** affects iOS too, not just desktop. Real connectivity monitoring on JVM needs an
+**Why last:** affects iOS too, not just desktop. Real connectivity monitoring on JVM needs an
 actual design decision (poll a socket? `InetAddress.isReachable`? watch `NetworkInterface` changes?)
-that's worth scoping deliberately rather than assuming here, same reasoning task 5 already uses for
-gating the logger backend.
+that's worth scoping deliberately rather than assuming here, same reasoning task 5 uses for its own
+open design questions.
 
-**Scope, if approved:** to be decided when this task is actually scoped — resolve the JVM detection
+**Scope:** to be decided when this task is actually started — resolve the JVM detection
 strategy, then give `NetworkMonitorImpl.jvm.kt` a real implementation. iOS is explicitly out of scope
-for this Linux-release-scoped plan even if approved.
+for this Linux-release-scoped plan.
 
 ---
 

--- a/docs/desktop/linux-release-plan.md
+++ b/docs/desktop/linux-release-plan.md
@@ -42,16 +42,20 @@ file rather than pushing through.
 | 3 | Wire the `.deb` into the release workflow | M | ✅ done — 2026-08-09 |
 | 4 | Add `Rpm` as a second target format | XS | deferred — ask first |
 | 5 | Install a real logger backend on desktop | S | deferred — ask first |
-| 6 | Update README once Linux is actually distributed | XS | todo (do last, after 3) |
+| 6 | Update README once Linux is actually distributed | XS | todo (do last, after 3 and 7) |
+| 7 | Logout doesn't clear the local DB on desktop | S | ⬅ NEXT |
+| 8 | GitHub OAuth login is a dead button on desktop | S | deferred — ask first, do last |
+| 9 | Offline detection is a stub on desktop | S | deferred — ask first, do last |
 
 Sizes: XS = minutes, S = under an hour, M = a focused session.
 
-**Scope decision (2026-08-09):** tasks 0–3 and 6 are the straight-line path to "a Linux `.deb` a
+**Scope decision (2026-08-09):** tasks 0–3, 6, and 7 are the straight-line path to "a Linux `.deb` a
 user can actually download and run correctly" and are in scope to work straight through. Tasks 4–5
 are real improvements but not required for a first release — **gated on asking first**, same
 convention `docs/testing/improvement-plan.md` uses for its own gated items. Task 6 depends on 3
-landing (no point documenting a distribution channel that doesn't exist yet) but is otherwise trivial
-and does not need to wait for 4–5.
+landing (no point documenting a distribution channel that doesn't exist yet) and now also on 7 (no
+point calling the release straight-line-done while a known data bug sits unfixed) but is otherwise
+trivial and does not need to wait for 4–5.
 
 Task ordering rationale: 0 unblocks everything else (nothing downstream can be verified against a
 build that doesn't produce a package). 1 is the correctness bug that matters most to a real user and
@@ -59,6 +63,14 @@ has no dependency on 0 having landed, but is listed second because it's less urg
 packages at all*. 2 depends on 0 (the CI job would fail on the same icon bug) and should land before
 3 (proving the package builds in CI before wiring it into a release is cheaper to debug). 3 depends
 on 0–2.
+
+**Tasks 7–9 added 2026-08-09**, after a post-task-3 audit (prompted by gregory suspecting desktop
+gets the same short shrift as iOS) turned up three real JVM-actual gaps beyond the original three the
+survey found. Task 7 is in scope now because it's a plain data-correctness bug in the same family as
+task 1 (a JVM actual silently doing nothing where Android's does real work) and is cheap. Tasks 8 and
+9 are real but explicitly **deferred to last, per gregory (2026-08-09)** — both also affect iOS, not
+just desktop, which makes them bigger than a Linux-release-scoped fix, and neither blocks a user from
+successfully installing and using a first `.deb` release the way tasks 0–3 and 7 do.
 
 ---
 
@@ -354,6 +366,89 @@ and build locally, per the survey, but nothing in this plan wires them into CI o
 imply they're supported just because `Dmg`/`Msi` appear in the same Gradle block).
 
 **Finalize focus:** low.
+
+---
+
+## Task 7 — Logout doesn't clear the local DB on desktop
+
+**Why:** `AuthStateManager.logoutSuspend()` (`core/storage/src/commonMain/kotlin/com/grappim/taigamobile/core/storage/auth/AuthStateManager.kt`)
+clears session/auth storage and calls `databaseWrapper.clearAllTablesKmp()` to wipe the local Room
+cache. The `expect fun TaigaDB.clearAllTablesKmp()` actuals live in `core/storage/src/*/kotlin/com/grappim/taigamobile/core/storage/db/TaigaDBExt.*.kt`:
+Android's really calls `clearAllTables()`; **JVM's and iOS's are both `actual fun TaigaDB.clearAllTablesKmp() = Unit`** — a
+silent no-op. Verified by reading all three files directly. On desktop, logging out and logging back
+in as a different Taiga account (or a different server) leaves the previous account's cached
+projects/sprints/tasks/wiki rows sitting in the local DB — a real data-correctness bug, same family as
+task 1's storage-path bug (a JVM actual quietly doing nothing where Android's does real work).
+
+**Scope:** implement `TaigaDBExt.jvm.kt`'s actual identically to Android's —
+`actual fun TaigaDB.clearAllTablesKmp() = clearAllTables()`. Confirmed safe to copy verbatim:
+`TaigaDB` (`core/storage/src/commonMain/.../db/TaigaDB.kt:35`) extends the KMP-shared `RoomDatabase()`,
+so `clearAllTables()` isn't Android-specific — it's the same zero-arg Room method on every platform.
+The IO-dispatcher hop already happens one level up in `DatabaseWrapperImpl.clearAllTables()`, so the
+actual itself needs no dispatcher handling of its own. **iOS's identical stub is out of scope for this
+task** — this plan is Linux-desktop-scoped, and there's no way to exercise the iOS actual here to
+verify the same one-liner is correct there too. Leave iOS alone; don't fix it as a drive-by.
+
+**Done when:** on desktop, log in as one Taiga account, load some data (visit a project so it's
+cached), log out, log in as a different account (or point at a different server), and confirm the
+first account's cached rows are gone — not just that the UI shows the new account's data (which could
+be cache-first-then-refetch masking the bug), but that the local DB file itself no longer has the old
+rows. `./gradlew jvmTest` must stay green.
+
+**Finalize focus:** low — small, mechanical fix once the actual is found; note if `TaigaDB`'s
+generated `clearAllTables()` needed anything beyond a direct call (e.g. running off the DB dispatcher)
+that Android's one-liner didn't make obvious was needed.
+
+---
+
+## Task 8 — GitHub OAuth login is a dead button on desktop
+
+⛔ **Gated — do not start without asking (see status table). Deferred to last per gregory (2026-08-09).**
+
+**Why, if approved:** `LoginScreen.kt` wires the "Continue with GitHub" button unconditionally on all
+platforms. `LoginViewModel.startGithubOAuth()` succeeds (fetches the OAuth client ID) and fires an
+event that opens `GithubOAuthWebViewDialog` — a real in-app WebView flow on Android
+(`GithubOAuthWebViewDialog.android.kt`), but on JVM (`feature/login/ui/src/jvmMain/kotlin/com/grappim/taigamobile/feature/login/ui/GithubOAuthWebViewDialog.jvm.kt`)
+it's `actual fun GithubOAuthWebViewDialog(...) = Unit` — verified by reading the file directly. A
+desktop user clicks the button, sees a brief loading state, then nothing happens, with no error or
+explanation. `docs/features/github-auth/plan.md` already lists "iOS / Desktop OAuth" as out of scope,
+so the missing *implementation* is a known, intentional deferral — what's not intentional is that the
+button doesn't reflect that: it should be hidden or disabled on JVM (and iOS, which has the identical
+stub), not silently swallow the click.
+
+**Why deferred:** affects iOS too, not just desktop, so it's bigger than this Linux-release-scoped
+plan; and it doesn't block a user from installing and using a first `.deb` release, since the rest of
+login (username/password, presumably) works normally.
+
+**Scope, if approved:** hide or disable the GitHub button on platforms where
+`GithubOAuthWebViewDialog` is a no-op, rather than implementing the actual WebView flow for JVM/iOS
+(that would be a much bigger task and isn't what's being asked here — confirm scope again before
+starting, since "hide the button" and "implement OAuth for desktop" are very different sizes).
+
+---
+
+## Task 9 — Offline detection is a stub on desktop
+
+⛔ **Gated — do not start without asking (see status table). Deferred to last per gregory (2026-08-09).**
+
+**Why, if approved:** `LocalOfflineState` (`uikit`) is driven by `MainViewModel.isOffline`, which
+reads `NetworkMonitor.isOnline`. `NetworkMonitorImpl` has three implementations, all in
+`core/storage/src/*/kotlin/com/grappim/taigamobile/core/storage/network/`: Android's
+(`androidMain/.../NetworkMonitorImpl.kt`) really registers a `ConnectivityManager.NetworkCallback`;
+**JVM's and iOS's (`jvmMain`/`iosMain`, both named `NetworkMonitorImpl.jvm.kt`/`.ios.kt`) hardcode
+`MutableStateFlow(true)` and never update it** — verified by reading the JVM file directly (iOS
+reported identical by the auditing pass, not independently re-verified here). Desktop (and iOS) always
+reports online: the offline banner never shows, and no write action is ever disabled for connectivity
+reasons on those two platforms, contrary to CLAUDE.md's documented offline-state convention.
+
+**Why deferred:** affects iOS too, not just desktop. Real connectivity monitoring on JVM needs an
+actual design decision (poll a socket? `InetAddress.isReachable`? watch `NetworkInterface` changes?)
+that's worth scoping deliberately rather than assuming here, same reasoning task 5 already uses for
+gating the logger backend.
+
+**Scope, if approved:** to be decided when this task is actually scoped — resolve the JVM detection
+strategy, then give `NetworkMonitorImpl.jvm.kt` a real implementation. iOS is explicitly out of scope
+for this Linux-release-scoped plan even if approved.
 
 ---
 

--- a/docs/desktop/linux-release-plan.md
+++ b/docs/desktop/linux-release-plan.md
@@ -41,8 +41,8 @@ file rather than pushing through.
 | 3 | Wire the `.deb` into the release workflow | M | ✅ done — 2026-08-09 |
 | 4 | Add `Rpm` as a second target format | XS | todo |
 | 5 | Install a real logger backend on desktop | S | todo |
-| 6 | Update README once Linux is actually distributed | XS | todo (do last, after 3 and 7) |
-| 7 | Logout doesn't clear the local DB on desktop | S | ⬅ NEXT |
+| 6 | Update README once Linux is actually distributed | XS | ⬅ NEXT |
+| 7 | Logout doesn't clear the local DB on desktop | S | ✅ done — 2026-08-09 |
 | 8 | GitHub OAuth login is a dead button on desktop | S | todo (do last) |
 | 9 | Offline detection is a stub on desktop | S | todo (do last) |
 
@@ -400,6 +400,45 @@ rows. `./gradlew jvmTest` must stay green.
 **Finalize focus:** low — small, mechanical fix once the actual is found; note if `TaigaDB`'s
 generated `clearAllTables()` needed anything beyond a direct call (e.g. running off the DB dispatcher)
 that Android's one-liner didn't make obvious was needed.
+
+**Result (2026-08-09):** The task's premise — "confirmed safe to copy verbatim... it's the same
+zero-arg Room method on every platform" — turned out to be **wrong**, discovered only by actually
+compiling. Room 2.8.4's KMP `RoomDatabase` actual has a *different* member surface per target:
+`clearAllTables()` is Android-only (verified via `javap` on the Android vs. JVM `room-runtime`
+artifacts — the JVM/native actual's `RoomDatabase` doesn't declare it at all). Copying Android's
+one-liner into `TaigaDBExt.jvm.kt` failed with "Unresolved reference 'clearAllTables'".
+
+**What was actually done instead:** added a no-arg `deleteAll()` `@Query` to each of the three DAOs
+(`ProjectDao`, `SprintDao`, `WorkItemDao` — same pattern as their existing `deleteByProjectId`/
+`deleteOlderThan` queries), and JVM's actual now calls all three:
+```kotlin
+actual suspend fun TaigaDB.clearAllTablesKmp() {
+    projectDao().deleteAll()
+    sprintDao().deleteAll()
+    workItemDao().deleteAll()
+}
+```
+This forced `expect fun TaigaDB.clearAllTablesKmp()` to become `suspend` (DAO deletes are suspend
+functions) — which in turn required adding the `suspend` keyword to the Android and iOS actuals too,
+purely to keep the expect/actual signatures matching. **iOS's stub body is still `= Unit`**, exactly
+as scoped — only its signature changed, not its behavior; the task's "leave iOS alone" instruction
+was honored. Also had to implement `deleteAll()` on the three `Fake*Dao` classes in `:testing`
+(`error("not used in this test")`, matching the existing convention for unexercised methods) since
+Kotlin's compiler enforces the interface change at every implementer, fakes included.
+
+**Verified end-to-end, not just compiled — same rigor as task 1, gregory approved driving the GUI
+with `xdotool` first.** Ran `:composeApp:run` against the local dev Taiga instance (`docs/local-info.md`),
+logged in as `admin`/`admin` (session already persisted from task 1's earlier run), navigated into a
+project's Open Sprints and a sprint's board to populate all three cache tables
+(`sqlite3 ~/.local/share/TaigaMobile/taigamobilenova.db` showed 1 project / 3 sprints / 6 work items),
+then logged out via the drawer's "Log out" → confirm dialog. Immediately re-queried the DB file: **all
+three tables were 0 rows** — the bug is fixed. Logged back in as a different account (`user1`/`user1`,
+which has its own distinct project, `main-2`/"Main project") to confirm normal operation resumes; the
+DB then showed exactly that new account's single project with no leftover admin-session rows.
+`./gradlew jvmTest` and `ktlintCheck` both green across the whole repo.
+
+Next: task 6, updating the README — it was gated on both task 3 (done earlier today) and this task,
+and both are now done.
 
 ---
 

--- a/docs/desktop/linux-release-plan.md
+++ b/docs/desktop/linux-release-plan.md
@@ -632,6 +632,15 @@ the failure path doesn't depend on any particular local network's error behavior
 low additional value once the pure function is covered) — same precedent as task 5's `FileLogger`,
 which also has no test. `./gradlew jvmTest` and `ktlintCheck` both green across the whole repo.
 
+**CI caught something local verification missed: `detekt` was never run locally before the first
+push, and it failed** — `SwallowedException` on `catch (e: IOException) { false }`, since `e` is
+never read. Fixed by renaming the caught variable to `expected`, which the project's own
+`config/detekt/detekt.yml` (`SwallowedException.allowedExceptionNameRegex: '_|(ignore|expected).*'`)
+already treats as "yes, this is deliberate" rather than needing a `@Suppress`. `./gradlew detekt`
+(root, matching the CI step exactly) and `jvmTest` both green after the fix. Lesson for next time:
+run `./gradlew detekt` locally alongside `jvmTest`/`ktlintCheck` before pushing, not just after CI
+flags it.
+
 **Verified end-to-end, not just compiled — but split between us this time.** I ran
 `:composeApp:run` and confirmed the online path live: login screen renders normally with no offline
 banner, and `taigamobile.log` stays clean (no spurious "Network connectivity changed" lines while

--- a/docs/desktop/linux-release-plan.md
+++ b/docs/desktop/linux-release-plan.md
@@ -1,5 +1,11 @@
 # Desktop Linux release: implementation plan
 
+**Status: CLOSED — 2026-08-09.** All 10 tasks (0–9) are done; the status table below has no `todo`
+left. Kept as the historical record of what was done and how — task write-ups and per-task Result
+notes stay here rather than being deleted. **Ideas that were surveyed but not actioned moved to
+[deferred.md](deferred.md)** — that's now the place to look for what's still open, not the
+"Considered and deferred" section this file used to end with.
+
 **Created:** 2026-08-09
 **Baseline:** [survey.md](survey.md) — what the desktop target looks like before this plan started.
 
@@ -44,7 +50,7 @@ file rather than pushing through.
 | 6 | Update README once Linux is actually distributed | XS | ✅ done — 2026-08-09 |
 | 7 | Logout doesn't clear the local DB on desktop | S | ✅ done — 2026-08-09 |
 | 8 | GitHub OAuth login is a dead button on desktop | S | ✅ done — 2026-08-09 |
-| 9 | Offline detection is a stub on desktop | S | todo (do last) ⬅ NEXT |
+| 9 | Offline detection is a stub on desktop | S | ✅ done — 2026-08-09 |
 
 Sizes: XS = minutes, S = under an hour, M = a focused session.
 
@@ -601,14 +607,43 @@ open design questions.
 strategy, then give `NetworkMonitorImpl.jvm.kt` a real implementation. iOS is explicitly out of scope
 for this Linux-release-scoped plan.
 
----
+**Result (2026-08-09):** Detection strategy was a genuine open question, so it was put to gregory
+before implementing rather than assumed: **TCP reachability poll**, not a `NetworkInterface`
+link-state check — chosen because it matches Android's actual "is there real internet" semantics
+(catches router-up-but-ISP-down, not just link-down) even though it costs a small periodic outbound
+connection while the app runs.
 
-## Considered and deferred
+**Implementation:** `NetworkMonitorImpl.jvm.kt` now polls a top-level `internal fun
+isHostReachable(host, port, timeoutMs): Boolean` (plain `java.net.Socket` connect, no new
+dependency) against `1.1.1.1:53` every 5s from a coroutine launched in `init` on `@ApplicationScope`
++ `@IoDispatcher` (same qualifier pattern as `AuthStateManager`/`DatabaseWrapperImpl`). `_isOnline`
+starts optimistic (`true`) and self-corrects on the first check, typically within one
+`CONNECT_TIMEOUT_MS` (2s) of startup — called out explicitly in the class's KDoc as a real deviation
+from Android's actual, which can query `ConnectivityManager` synchronously for an accurate initial
+value with no network round-trip. Transitions are logged (`logcat(LogPriority.INFO)`) only when
+`online` actually changes, not on every poll — logging every failed check while genuinely offline
+would spam the 5 MB-capped log file task 5 just built.
 
-| Idea | Why deferred |
-|---|---|
-| AppImage / Flatpak / Snap | Real additional infrastructure (signing keys, store manifests, Flathub/Snap Store review) — worth it only once the `.deb`-via-GitHub-Releases path (tasks 0–3) is proven to work end-to-end and there's a concrete reason `.deb`-only isn't enough. |
-| Apt repository (so users get updates via `apt upgrade` instead of re-downloading) | Needs a signing key and hosting; same "prove the simple path first" reasoning as above. |
-| Auto-update mechanism inside the app | Not attempted — no existing infra to build on (see survey); a reasonable follow-up once there's more than one release to update *to*. |
-| arm64 Linux build | jpackage packages for the runner's own architecture only; would need a second CI job on an arm64 runner. Not scoped — revisit if there's actual user demand. |
-| macOS/Windows CI + release wiring | Out of scope for this plan (titled Linux release deliberately) — `Dmg`/`Msi` target formats already exist in the Gradle config and build locally per the survey, but wiring them into CI/release is a separate plan, not folded in here to keep this one small. |
+**Testing:** added `NetworkMonitorImplJvmTest` exercising `isHostReachable` directly against real
+sockets (per CLAUDE.md's "prefer the platform whose actual is real" convention) — `1.1.1.1:53` for
+the true branch, `192.0.2.1` (RFC 5737 TEST-NET-1, guaranteed non-routable) for the false branch, so
+the failure path doesn't depend on any particular local network's error behavior. The class's own
+5-second polling loop was deliberately **not** given a test (would need real sleeps in the suite for
+low additional value once the pure function is covered) — same precedent as task 5's `FileLogger`,
+which also has no test. `./gradlew jvmTest` and `ktlintCheck` both green across the whole repo.
+
+**Verified end-to-end, not just compiled — but split between us this time.** I ran
+`:composeApp:run` and confirmed the online path live: login screen renders normally with no offline
+banner, and `taigamobile.log` stays clean (no spurious "Network connectivity changed" lines while
+genuinely online, confirming the transition-only logging works). For the offline path, actually
+cutting this machine's network would have disrupted whatever else was using it, so I asked first
+rather than doing it myself; gregory then disconnected the network directly against the running app
+and confirmed the offline banner appeared correctly — approved as "it works fine."
+
+**Dead code noticed, not touched:** `androidApp/src/main/kotlin/com/grappim/taigamobile/data/ConnectivityManagerNetworkMonitor.kt`
+is a second, unused `NetworkMonitor`-shaped class (not the one actually wired via DI) discovered
+while checking `@param:IoDispatcher` usage patterns — out of scope for this task, logged to
+[docs/revisit.md](../revisit.md#31-unused-duplicate-connectivitymanagernetworkmonitor-in-androidapp).
+
+This was the last task in the plan (0–9 all done). Queue is empty — no task is scoped next in this
+plan. Follow-ups that were surveyed but not actioned now live in [deferred.md](deferred.md).

--- a/docs/desktop/linux-release-plan.md
+++ b/docs/desktop/linux-release-plan.md
@@ -43,8 +43,8 @@ file rather than pushing through.
 | 5 | Install a real logger backend on desktop | S | ✅ done — 2026-08-09 |
 | 6 | Update README once Linux is actually distributed | XS | ✅ done — 2026-08-09 |
 | 7 | Logout doesn't clear the local DB on desktop | S | ✅ done — 2026-08-09 |
-| 8 | GitHub OAuth login is a dead button on desktop | S | todo (do last) ⬅ NEXT |
-| 9 | Offline detection is a stub on desktop | S | todo (do last) |
+| 8 | GitHub OAuth login is a dead button on desktop | S | ✅ done — 2026-08-09 |
+| 9 | Offline detection is a stub on desktop | S | todo (do last) ⬅ NEXT |
 
 Sizes: XS = minutes, S = under an hour, M = a focused session.
 
@@ -548,6 +548,33 @@ login (username/password, presumably) works normally.
 `GithubOAuthWebViewDialog` is a no-op, rather than implementing the actual WebView flow for JVM/iOS
 (that would be a much bigger task and isn't what's being asked here — confirm scope again before
 starting, since "hide the button" and "implement OAuth for desktop" are very different sizes).
+
+**Result (2026-08-09):** Confirmed scope was still "hide the button", not "implement OAuth for
+JVM/iOS", before starting. Added `expect fun isGithubOAuthSupported(): Boolean` to
+`GithubOAuthWebViewDialog.kt` (commonMain), right next to the existing `expect fun
+GithubOAuthWebViewDialog(...)` it's paired with — `actual = true` on Android, `actual = false` on
+both JVM and iOS (their `GithubOAuthWebViewDialog` actuals are the identical no-op stub). In
+`LoginScreen.kt`, wrapped the "Continue with GitHub" `OutlinedButton` and its two helper `Text`s
+(`login_github_server_required`, `login_github_setup_guide`) in `if (isGithubOAuthSupported()) { ...
+}` — conditional wrapping, not an early return, per CLAUDE.md's Compose rule (the file already used
+the same `if/else` shape for `state.isLoading`). No ViewModel or `LoginState` change needed: this is
+a static per-platform capability, not runtime state, so a plain top-level expect/actual function was
+the right size — no new state field, no DI.
+
+**Verified on all three platforms, not just JVM:** `:feature:login:ui:compileKotlinJvm` +
+`:feature:login:ui:jvmTest` green, `:feature:login:ui:compileAndroidMain` green, and
+`:feature:login:ui:compileKotlinIosArm64` green (confirms Android keeps the button and iOS also gets
+it hidden, even though iOS packaging is out of this plan's scope — the fix lives in shared
+`feature/login/ui`, so both non-Android platforms had to compile). Full `./gradlew jvmTest
+ktlintCheck` across the whole repo green afterward.
+
+**Verified visually on desktop, not just compiled.** Ran `:composeApp:run`, logged out of the
+already-persisted session (gregory drove this part directly rather than continuing unreliable
+`xdotool` clicks — screenshotting the whole display instead of just the app window was making the
+click coordinates unreliable), and confirmed on the real login screen: only **Continue** and
+**Continue with LDAP** are present — the GitHub button and both of its helper lines are gone.
+
+Next: task 9, offline detection is a stub on desktop — the last task in this plan.
 
 ---
 

--- a/docs/desktop/linux-release-plan.md
+++ b/docs/desktop/linux-release-plan.md
@@ -36,8 +36,8 @@ file rather than pushing through.
 
 | # | Task | Size | Status |
 |---|---|---|---|
-| 0 | Fix the broken icon path | XS | ⬅ NEXT |
-| 1 | Move desktop storage off `java.io.tmpdir` | S | todo |
+| 0 | Fix the broken icon path | XS | ✅ done — 2026-08-09 |
+| 1 | Move desktop storage off `java.io.tmpdir` | S | ⬅ NEXT |
 | 2 | CI job: build the Linux package on PRs | S | todo |
 | 3 | Wire the `.deb` into the release workflow | M | todo |
 | 4 | Add `Rpm` as a second target format | XS | deferred — ask first |
@@ -87,6 +87,14 @@ exact command the survey used to prove the bug; use it to prove the fix, don't j
 **Finalize focus:** low — this is a pure bug fix with an obvious verification command. Worth noting
 in the finalize pass only if the produced `.deb` has anything else visibly wrong (bad icon rendering,
 wrong menu category) since this task is the first time anyone has looked at the output at all.
+
+**Result (2026-08-09):** Three one-line edits applied exactly as scoped. Verified with
+`./gradlew :composeApp:packageDistributionForCurrentOS` — `packageDeb` succeeded, producing
+`composeApp/build/compose/binaries/main/deb/taigamobile_2.1.5_amd64.deb` (`packageDmg`/`packageMsi`
+skipped, as expected on Linux). `dpkg -I` confirms sane metadata (package `taigamobile`, version
+`2.1.5`, correct maintainer/deps). Extracted the `.deb` and confirmed the embedded icon
+(`opt/taigamobile/lib/TaigaMobile.png`) is a real 1024×1024 RGBA PNG, not empty/placeholder — nothing
+else visibly wrong. Next: task 1, moving desktop storage off `java.io.tmpdir`.
 
 ---
 

--- a/docs/desktop/linux-release-plan.md
+++ b/docs/desktop/linux-release-plan.md
@@ -40,10 +40,10 @@ file rather than pushing through.
 | 2 | CI job: build the Linux package on PRs | S | ✅ done — 2026-08-09 |
 | 3 | Wire the `.deb` into the release workflow | M | ✅ done — 2026-08-09 |
 | 4 | Add `Rpm` as a second target format | XS | ✅ done — 2026-08-09 |
-| 5 | Install a real logger backend on desktop | S | todo ⬅ NEXT |
+| 5 | Install a real logger backend on desktop | S | ✅ done — 2026-08-09 |
 | 6 | Update README once Linux is actually distributed | XS | ✅ done — 2026-08-09 |
 | 7 | Logout doesn't clear the local DB on desktop | S | ✅ done — 2026-08-09 |
-| 8 | GitHub OAuth login is a dead button on desktop | S | todo (do last) |
+| 8 | GitHub OAuth login is a dead button on desktop | S | todo (do last) ⬅ NEXT |
 | 9 | Offline detection is a stub on desktop | S | todo (do last) |
 
 Sizes: XS = minutes, S = under an hour, M = a focused session.
@@ -387,6 +387,41 @@ per-user app-data directory task 1 introduces), installed from `TaigaMobileDeskt
 alongside the existing `FileKit.init(...)`/`startKoin(...)` calls. Rotation/size-capping policy and
 whether `CrashReporterImpl.jvm.kt` should also stop being a pure stub are open questions to resolve
 when this task is actually started, not decided here.
+
+**Result (2026-08-09):** Added `FileLogger` (`core/logger/src/jvmMain/.../FileLogger.kt`), a
+`TaigaLogger` implementation that appends formatted lines (timestamp, priority, tag, message,
+stack trace) to a file, synchronized for thread-safety, with a 5 MB size cap: once the target file
+exceeds that, it's renamed to `<name>.old` (overwriting any previous one) and a fresh file starts.
+Installed from `TaigaMobileDesktop.kt`'s `main()`, first thing before `FileKit.init(...)`, at
+`File(appDataDir(), "taigamobile.log")` — reusing task 1's `appDataDir()` helper
+(`core/storage/.../platform/AppDataDir.jvm.kt`), whose visibility was widened from `internal` to
+public for this cross-module use (`core/storage` doesn't depend on `core/logger` the other way, so
+no dependency cycle).
+
+**`CrashReporterImpl.jvm.kt` deliberately left untouched.** Checked call sites before deciding:
+`recordException()` is only ever invoked from `CrashlyticsTree.kt`, an Android-only Timber `Tree`
+integration (`androidApp/src/main/.../CrashlyticsTree.kt`) — nothing on desktop calls
+`crashReporter.recordException()` at all, since Timber itself is Android-only per CLAUDE.md's
+Logging table. Wiring the JVM stub to `logcat` would have been dead code with no caller, not a real
+fix, so it stayed a stub as scoped.
+
+**Verified end-to-end, not just compiled.** Ran `:composeApp:run` twice against the local dev Taiga
+instance (gregory approved driving the GUI with `xdotool`, same as tasks 1 and 7):
+1. First run: confirmed `~/.local/share/TaigaMobile/taigamobile.log` is created immediately and
+   fills with real content as the app runs — `MainViewModel` state lines and full Ktor
+   request/response logs (headers, bodies), not just a handful of boilerplate lines (595 lines after
+   one session touching a project/sprint). Closed the window, confirmed the process fully exited,
+   confirmed the file survives with its content intact (not truncated on close).
+2. Rotation check: manually `truncate -s 6M`'d the log file past the 5 MB cap, started the app
+   again, and confirmed on the very first write it renamed the 6 MB file to `taigamobile.log.old`
+   and started a fresh `taigamobile.log` — the cap is enforced on every write, not just at startup,
+   so a long-running session can't grow the file unbounded either. Cleaned up the synthetic 6 MB
+   `.old` file afterward; it was a test artifact, not real data.
+
+`./gradlew jvmTest` and `ktlintCheck` both green across the whole repo afterward.
+
+Next: task 8, hiding the dead GitHub OAuth button on desktop (and iOS) — the last two tasks (8, 9)
+are both explicitly ordered last per gregory; 8 is first in table order.
 
 ---
 

--- a/docs/desktop/linux-release-plan.md
+++ b/docs/desktop/linux-release-plan.md
@@ -38,8 +38,8 @@ file rather than pushing through.
 |---|---|---|---|
 | 0 | Fix the broken icon path | XS | ✅ done — 2026-08-09 |
 | 1 | Move desktop storage off `java.io.tmpdir` | S | ✅ done — 2026-08-09 |
-| 2 | CI job: build the Linux package on PRs | S | ⬅ NEXT |
-| 3 | Wire the `.deb` into the release workflow | M | todo |
+| 2 | CI job: build the Linux package on PRs | S | ✅ done — 2026-08-09 |
+| 3 | Wire the `.deb` into the release workflow | M | ⬅ NEXT |
 | 4 | Add `Rpm` as a second target format | XS | deferred — ask first |
 | 5 | Install a real logger backend on desktop | S | deferred — ask first |
 | 6 | Update README once Linux is actually distributed | XS | todo (do last, after 3) |
@@ -214,6 +214,31 @@ caught that regression.
 
 **Finalize focus:** medium — note whether `fakeroot` needed the explicit install step or was already
 present, since that's exactly the kind of CI-environment fact that's expensive to rediscover later.
+
+**Result (2026-08-09):** Added a `desktop-package` job to `.github/workflows/build.yml`, alongside
+the existing `build` job — reuses `android-setup-composite-action` (Java 21 + Gradle cache; the
+Android SDK setup it also does goes unused here, but keeping one setup action was judged not worth
+avoiding per the task's own note), installs `fakeroot` explicitly, then runs
+`./gradlew :composeApp:packageDeb` only (not `packageDistributionForCurrentOS`, which would also
+attempt Dmg/Msi).
+
+**`fakeroot` confirmed present on `ubuntu-latest` already** — the CI log shows `fakeroot is already
+the newest version (1.33-1)`, so the explicit install step is a no-op safety net rather than filling
+a real gap. Kept it anyway per the task's scope (protects against the runner image changing).
+
+**Verified both `Done when` conditions, not just "job is green":**
+1. Pushed to the existing open PR #345 (this plan's own branch,
+   `docs/desktop-linux-release-plan` — tasks 0–1 already lived there unmerged) and watched the run
+   via `gh run watch`: `desktop-package` passed in 3m48s.
+2. Locally reverted task 0's icon-path fix (one line, `../art/...` → `../info/art/...` in
+   `composeApp/build.gradle.kts`, uncommitted) and re-ran the exact command the job runs
+   (`./gradlew :composeApp:packageDeb`) — it failed with the same `Input file does not exist` error
+   the original survey documented, confirming this job would have caught that regression. Reverted
+   the local-only change immediately after (`git checkout -- composeApp/build.gradle.kts`); nothing
+   from this check was committed.
+
+No artifact upload, no `packageRpm`/`packageDmg`/`packageMsi` — out of scope per the task. Next: task
+3, wiring the `.deb` into the release workflow.
 
 ---
 

--- a/docs/desktop/survey.md
+++ b/docs/desktop/survey.md
@@ -1,0 +1,124 @@
+# Desktop (Linux) release: what exists today
+
+**Surveyed:** 2026-08-09 against `dev` (`06d35616`).
+**Scope:** whether the Compose Desktop JVM target can actually ship a Linux `.deb` right now —
+build config, packaging, storage, CI, and what a real user would hit. Descriptive, not a proposal —
+the proposal is [linux-release-plan.md](linux-release-plan.md).
+
+## TL;DR
+
+Desktop **builds and runs** (`./gradlew :composeApp:run` works), but **packaging is broken and has
+never been exercised**: `:composeApp:packageDeb` fails immediately on a bad icon path that has been
+wrong since it was introduced. Independently, and more seriously, every JVM-actual storage backend
+(Room DB, all four DataStores, server URL) writes into `java.io.tmpdir` instead of a real per-user
+data directory — so even once packaging works, a shipped build would lose logins and local data on
+reboot on most Linux setups. No CI workflow builds, packages, or even smoke-tests the desktop target
+at all. README already says as much plainly: "Desktop (Linux/macOS/Windows) | Builds & runs |
+Distribution TBD".
+
+## Packaging config
+
+`composeApp/build.gradle.kts`, `compose.desktop.application.nativeDistributions`:
+
+- `targetFormats(TargetFormat.Deb, TargetFormat.Dmg, TargetFormat.Msi)` — Linux only gets `Deb`
+  (Debian/Ubuntu family). No `Rpm` (jpackage supports it directly), no AppImage/Flatpak/Snap.
+- `packageName`/`packageVersion`/`description`/`vendor`/`copyright` are wired from
+  `gradle/libs.versions.toml` (`app-name`, `version-name`, `app-description`, `app-vendor`) — these
+  exist and are populated correctly.
+- `linux { debMaintainer, debPackageVersion, appCategory, menuGroup, shortcut }` all wired from the
+  same catalog entries (`app-vendor`, `app-category` = `"utils"`, `app-menugroup` = `"Office"`).
+- **`iconFile.set(project.file("../info/art/taiga-mobile-logo.png"))` — broken.** Resolves to
+  `<repo-root>/info/art/...`, which does not exist; the real assets live at `<repo-root>/art/...`
+  (confirmed: `git log -S"info/art"` shows the path was introduced wrong in `0d4f8ccf`, the KMP
+  migration PR #221, and never touched since). Same wrong prefix on the Windows (`.ico`) and macOS
+  (`.icns`) `iconFile` lines too.
+- **Verified by actually running it**: `./gradlew :composeApp:packageDistributionForCurrentOS`
+  reaches `:composeApp:checkRuntime` and `:composeApp:createRuntimeImage` successfully, then
+  `:composeApp:packageDeb` fails Gradle's task-input validation outright —
+  `Input file does not exist ... property 'iconFile' specifies file
+  '.../info/art/taiga-mobile-logo.png' which doesn't exist`. This is not a runtime/environment gap;
+  it is a one-line path bug that has silently blocked every attempt at packaging since #221.
+- Proguard (`proguard-desktop.pro`) is enabled for `buildTypes.release` and looks complete —
+  `-dontoptimize` plus keep rules for Koin, kotlinx.serialization, Room/SQLite bundled driver, the
+  Ktor OkHttp engine, and OkHttp/Okio itself. No obvious gaps; not exercised past compile since
+  packaging never got this far.
+
+## Storage — the bigger problem
+
+Every JVM-actual persistent store resolves its file path off `System.getProperty("java.io.tmpdir")`:
+
+| What | File | Where |
+|---|---|---|
+| Room DB | `taigamobilenova.db` | `core/storage/.../di/DBModule.jvm.kt` |
+| Auth tokens | `$AUTH_DATA_STORE_FILE_NAME` | `core/storage/.../di/StorageModule.jvm.kt` |
+| Session | `$TAIGA_SESSION_STORAGE` | same file |
+| Filters | `$SESSION_FILTERS_DATA_STORE_FILE_NAME` | same file |
+| Trusted certs | `$TRUSTED_CERT_DATA_STORE_FILE_NAME` | same file |
+| Server URL | `SERVER_STORAGE_FILE_NAME` | `core/storage/.../server/ServerStorageImpl.jvm.kt` |
+
+Compare with the iOS actuals for the exact same six stores (`ServerStorageImpl.ios.kt`,
+`StorageModule.ios.kt`), which correctly resolve `NSDocumentDirectory` via `NSFileManager`. The JVM
+side never got the equivalent treatment — `java.io.tmpdir` looks like it was a quick placeholder
+during the KMP migration that stuck.
+
+**Why this matters on Linux specifically:** `/tmp` (or wherever `java.io.tmpdir` points) is routinely
+tmpfs or cleared by `systemd-tmpfiles`/reboot on common distros. A real user would see their login
+session, trusted-certificate approvals, and local DB cache disappear unpredictably — most visibly, on
+every reboot. This is not a corner case; it is the normal operating condition of `/tmp` on a modern
+Linux desktop.
+
+Note: `java.io.tmpdir` is also the path `:testing/.../PlatformTestUtils.kt` and
+`composeApp/src/jvmTest/.../LiveTaigaSession.kt` use deliberately for tests — that usage is correct
+and unrelated; the bug is that **production** code (`DBModule.jvm.kt`, `StorageModule.jvm.kt`,
+`ServerStorageImpl.jvm.kt`, all under `src/jvmMain`, not `jvmTest`) shares the same call.
+
+## CI
+
+Three workflows exist; none touch the desktop target:
+
+- `build.yml` — PR gate, builds `androidApp:assembleFdroidDebug` + `assembleGplayDebug` only.
+- `code_analysis.yml` — detekt, ktlint, `jvmTest` (this *does* run desktop-touching `jvmTest`/
+  `commonTest` code, since JVM is a real KMP target — but never runs `packageDistributionForCurrentOS`
+  or any packaging task), Kover, `koverVerify`.
+- `release.yml` — tag-triggered, builds only Android APKs/AAB and creates the GitHub Release.
+
+So the icon-path bug above has had no way to be caught — nothing in CI has ever invoked
+`packageDeb`/`packageDistributionForCurrentOS`.
+
+## Diagnosability on desktop (existing, documented gaps — not new findings)
+
+- `TaigaMobileDesktop.kt` (the desktop `main()`) never calls `TaigaLogger.install(...)`. Per
+  CLAUDE.md's Logging table, Desktop/JVM falls back to the no-op `NoLog` backend — every `logcat {}`
+  call site is silently dropped. Android and iOS both install a real backend from their entry points;
+  desktop never has.
+- `CrashReporterImpl.jvm.kt` is a stub: `isAvailable = false`, every method a no-op. No crash
+  telemetry of any kind on desktop.
+- Combined with the storage bug above, a Linux user hitting a real problem after a first release
+  would be close to undiagnosable from the vendor side: no logs, no crash reports, and the most
+  likely symptom ("I keep getting logged out") is itself a consequence of the storage bug, not a
+  separate report.
+
+## Toolchain / CI environment notes
+
+- `jpackage --type deb` needs `dpkg-deb` (present on any Debian/Ubuntu-based runner, including
+  `ubuntu-latest`) and `fakeroot` (confirmed present on this dev machine; **not confirmed** on
+  GitHub-hosted `ubuntu-latest` runners — worth an explicit `apt-get install -y fakeroot` step rather
+  than assuming).
+- jpackage only ever packages for the host's own architecture. A `ubuntu-latest` (x86_64) CI runner
+  produces an amd64 `.deb` only — arm64 Linux is not covered without a second runner/job.
+- Local dev machine's `.java-version` is `24`; CI's `android-setup-composite-action` installs Java
+  `21` (Temurin). Both should have `jpackage` (bundled since JDK 16), but the combination running the
+  desktop packaging tasks specifically has not been exercised on JDK 21 — only informally on 24, here,
+  during this survey.
+
+## Distribution channel
+
+Not decided yet. Realistic options for a first release, roughly in order of effort:
+
+1. Attach the `.deb` as a GitHub Release asset (same pattern already used for the Android APKs/AAB in
+   `release.yml`) — no new infrastructure, users `dpkg -i` manually.
+2. Add `Rpm` to `targetFormats` for Fedora/openSUSE users — jpackage supports it as a sibling format
+   to `Deb` with no new tooling beyond what `rpmbuild` requires on the CI image.
+3. An apt repository, AppImage, Flatpak, or Snap — each is real additional infrastructure (signing
+   keys, packaging manifests, store review for Flathub/Snap Store) and is out of scope until (1) is
+   proven to work end-to-end.

--- a/docs/revisit.md
+++ b/docs/revisit.md
@@ -20,6 +20,8 @@ its own section, kept for the reasoning rather than the outcome):
 | 24 | `KoinGraphTest` and the live-Taiga integration tests collide on the JVM `DataStore` file, order-dependently | S–M | [testing agent, "Integration test against a live server"](../.claude/agents/testing.md) |
 | 27 | `ExpandableMarkdownTextTest` is flaky under a full `jvmTest` run (Skiko real-clock `waitUntil`) | S | this file, #27 |
 | 29 | Login screen's server-URL regex rejects bare `localhost` (no dot in hostname) | XS | this file, #29 |
+| 30 | `CrashReporter.recordException`/`.log` are unreachable on every non-Android platform | M | [desktop plan](desktop/linux-release-plan.md), this file #30 |
+| 31 | Unused duplicate `ConnectivityManagerNetworkMonitor` in `androidApp` | XS | this file, #31 |
 
 <details>
 <summary><strong>Full index (all 28 entries, resolved included)</strong> — this file is long because
@@ -58,6 +60,8 @@ moved out. Expand for a one-line-per-entry jump table instead of scrolling.</sum
 | 27 | [`ExpandableMarkdownTextTest.longTextShowsExpandButtonAndTogglesOnClick` is flaky](#27-expandablemarkdowntexttestlongtextshowsexpandbuttonandtogglesonclick-is-flaky-under-a-full-jvmtest-run) | 🟡 open |
 | 28 | [`CLAUDE.md` has grown too big; split the Kover ranking heuristics out into their own doc](#28-claudemd-has-grown-too-big-split-the-kover-ranking-heuristics-out-into-their-own-doc) | ✅ resolved 2026-08-09 |
 | 29 | [Login screen's server-URL regex rejects bare `localhost`](#29-login-screens-server-url-regex-rejects-bare-localhost) | 🟡 open |
+| 30 | [`CrashReporter.recordException`/`.log` are unreachable on every non-Android platform](#30-crashreporterrecordexceptionlog-are-unreachable-on-every-non-android-platform) | 🟡 open |
+| 31 | [Unused duplicate `ConnectivityManagerNetworkMonitor` in `androidApp`](#31-unused-duplicate-connectivitymanagernetworkmonitor-in-androidapp) | 🟡 open |
 
 </details>
 
@@ -1202,3 +1206,32 @@ would ever run.
 **Why deferred:** out of scope for task 5, which is specifically about the `logcat`/`TaigaLogger`
 file-logging path, not crash reporting — confirmed via the call-site grep rather than left as a
 guess, then left alone per the task's own scope boundary.
+
+## 31. Unused duplicate `ConnectivityManagerNetworkMonitor` in `androidApp`
+
+**Where:** `androidApp/src/main/kotlin/com/grappim/taigamobile/data/ConnectivityManagerNetworkMonitor.kt`
+
+**What happens:** this is a second, `@Single`-annotated connectivity monitor, separate from the one
+actually wired to the app's `NetworkMonitor` interface
+(`core/storage/src/androidMain/.../network/NetworkMonitorImpl.kt`, bound via `@Single(binds =
+[NetworkMonitor::class])`). It duplicates the same `ConnectivityManager.NetworkCallback` logic —
+`isOnline: Boolean` (point-in-time check) plus `isOnlineFlow: Flow<Boolean>` (callback-based) — but
+implements neither the `NetworkMonitor` interface nor binds to it, so nothing in the app can obtain
+it as `NetworkMonitor` even though Koin still constructs it as its own concrete-type single.
+
+**Evidence:** `grep -rln "ConnectivityManagerNetworkMonitor" --include=*.kt .` returns only the one
+declaration file — no injection site, no reference anywhere else in the repo.
+
+**Consequence:** dead weight in the Android DI graph (one extra `@Single` Koin has to construct and
+register, one extra `ConnectivityManager.NetworkCallback` registration if it's ever actually
+resolved) and a trap for the next reader trying to find "the" network monitor — two candidates exist
+with overlapping responsibility and only one is real.
+
+**Why deferred:** found while checking `@param:IoDispatcher` usage patterns for
+[docs/desktop/linux-release-plan.md](desktop/linux-release-plan.md) task 9 (JVM connectivity
+detection) — unrelated to that task's `core/storage` `jvmMain` scope, and deleting an
+`androidApp`-only file is a separate, single-purpose diff.
+
+**Fix, if wanted:** delete the file. Confirm first that Koin's `@ComponentScan` in `AndroidModule`
+(scans `com.grappim.taigamobile.data`) doesn't have some other reflective dependency on it existing —
+unlikely given zero references, but worth a `:androidApp:assembleGplayDebug` after removal to be sure.

--- a/docs/revisit.md
+++ b/docs/revisit.md
@@ -1172,3 +1172,33 @@ doesn't change any *behavior* for currently-valid inputs — worth a quick check
 
 **Why deferred:** unrelated to the storage-path task in progress; a validation-regex change belongs
 in its own diff.
+
+## 30. `CrashReporter.recordException`/`.log` are unreachable on every non-Android platform
+
+**Where:** `core/crash-api/src/commonMain/kotlin/com/grappim/taigamobile/core/crashapi/CrashReporter.kt`
+defines the interface; `composeApp/src/jvmMain/.../data/CrashReporterImpl.jvm.kt` and
+`composeApp/src/iosMain/.../data/CrashReporterImpl.ios.kt` are both pure no-op stubs.
+
+**What happens:** the only call site for `recordException()` anywhere in the codebase is
+`androidApp/src/main/kotlin/com/grappim/taigamobile/data/CrashlyticsTree.kt` — a Timber `Tree` that
+forwards `Timber.e(throwable)` calls to `crashReporter.recordException(t)`. Timber itself is
+Android-only (per CLAUDE.md's Logging table), so this `Tree` is never installed on JVM/iOS. Nothing
+else in the app calls `CrashReporter.recordException()` or `.log()` directly. Net effect: even if
+the JVM/iOS stubs were implemented for real, there is currently no code path that would ever invoke
+them — the interface is fully wired for Android only.
+
+**Evidence:** found while scoping [docs/desktop/linux-release-plan.md](desktop/linux-release-plan.md)
+task 5 (installing a real logger backend on desktop), which explicitly asked whether
+`CrashReporterImpl.jvm.kt` should stop being a stub in the same pass. `grep -rn
+"\.recordException("` across the repo returned exactly one non-test call site, confirming this
+rather than assuming it.
+
+**Consequence:** no observable bug today (nothing is silently dropped that was ever going to fire),
+but it means "wire up desktop crash reporting" is a bigger task than filling in the two stub
+methods — it also needs a JVM/iOS equivalent of the Timber-to-`CrashReporter` bridge (e.g. a global
+uncaught-exception handler, or a `logcat` call site added directly at error sites) before the stubs
+would ever run.
+
+**Why deferred:** out of scope for task 5, which is specifically about the `logcat`/`TaigaLogger`
+file-logging path, not crash reporting — confirmed via the call-site grep rather than left as a
+guess, then left alone per the task's own scope boundary.

--- a/docs/revisit.md
+++ b/docs/revisit.md
@@ -19,6 +19,7 @@ its own section, kept for the reasoning rather than the outcome):
 | 1 | ViewModels doing I/O in `init` | M–L | [koingraphtest issue](issues/2026-08-02-koingraphtest-leaks-coroutine-exceptions.md) |
 | 24 | `KoinGraphTest` and the live-Taiga integration tests collide on the JVM `DataStore` file, order-dependently | S–M | [testing agent, "Integration test against a live server"](../.claude/agents/testing.md) |
 | 27 | `ExpandableMarkdownTextTest` is flaky under a full `jvmTest` run (Skiko real-clock `waitUntil`) | S | this file, #27 |
+| 29 | Login screen's server-URL regex rejects bare `localhost` (no dot in hostname) | XS | this file, #29 |
 
 <details>
 <summary><strong>Full index (all 28 entries, resolved included)</strong> — this file is long because
@@ -56,6 +57,7 @@ moved out. Expand for a one-line-per-entry jump table instead of scrolling.</sum
 | 26 | [`WikiPageViewModelTest.onAttachmentAdd failure updates state with error` is flaky](#26-wikipageviewmodeltestonattachmentadd-failure-updates-state-with-error-is-flaky-under-a-full-jvmtest-run) | ✅ resolved 2026-08-08 |
 | 27 | [`ExpandableMarkdownTextTest.longTextShowsExpandButtonAndTogglesOnClick` is flaky](#27-expandablemarkdowntexttestlongtextshowsexpandbuttonandtogglesonclick-is-flaky-under-a-full-jvmtest-run) | 🟡 open |
 | 28 | [`CLAUDE.md` has grown too big; split the Kover ranking heuristics out into their own doc](#28-claudemd-has-grown-too-big-split-the-kover-ranking-heuristics-out-into-their-own-doc) | ✅ resolved 2026-08-09 |
+| 29 | [Login screen's server-URL regex rejects bare `localhost`](#29-login-screens-server-url-regex-rejects-bare-localhost) | 🟡 open |
 
 </details>
 
@@ -1134,3 +1136,39 @@ after the removed span. `CLAUDE.md` is now 440 lines (was 717). Checked `docs/te
 `improvement-plan.md` and `deferred.md` for references to the moved content by line number or quoted
 anchor text — none exist, so no cross-reference updates were needed. Docs-only change; no build/test
 commands to run.
+
+---
+
+## 29. Login screen's server-URL regex rejects bare `localhost`
+
+**Where:** `feature/login/ui/src/commonMain/kotlin/com/grappim/taigamobile/feature/login/ui/LoginViewModel.kt:33`
+
+```kotlin
+private const val SERVER_REGEX = """(http|https)://([\w\d-]+\.)+[\w\d-]+(:\d+)?(/\w+)*/?"""
+```
+
+**What happens:** the `([\w\d-]+\.)+` group requires at least one dot-separated label before the
+final hostname segment, i.e. it demands a real FQDN (`api.taiga.io`, `example.com`). A single-label
+host like `http://localhost:9000` fails `.matches(SERVER_REGEX)`, so `LoginViewModel.login()`
+(`:109`) sets `isServerInputError = true` and the field renders red — the request is never sent, with
+no error message beyond the red outline.
+
+**Evidence:** found manually verifying [docs/desktop/linux-release-plan.md](desktop/linux-release-plan.md)
+task 1 (moving desktop storage off `java.io.tmpdir`) — driving the real desktop app's login screen
+against the local dev Taiga instance (`http://localhost:9000`, per this project's memory) via
+`xdotool`. Typing `http://localhost:9000` produced the red-outlined field; switching to
+`http://127.0.0.1:9000` (which does satisfy the regex — each dot-separated octet matches
+`([\w\d-]+\.)+`) passed validation and logged in successfully.
+
+**Consequence:** cosmetic/dev-workflow only, not a production bug — no real Taiga deployment is
+reachable at a bare single-label hostname. It only bites developers and self-hosters pointing the
+app at `http://localhost:<port>` (a Docker-hosted instance, a reverse-proxied instance without a
+registered domain, etc.), who have to remember to type `127.0.0.1` instead.
+
+**Fix, if wanted:** loosen `SERVER_REGEX`'s host group to `([\w\d-]+\.)*[\w\d-]+`, allowing a
+single-label host without a trailing dot. Widens what "valid" data can be sent to `login()` but
+doesn't change any *behavior* for currently-valid inputs — worth a quick check that no other code
+(e.g. cert-pinning, `HostSelectionPlugin`) assumes a dotted hostname.
+
+**Why deferred:** unrelated to the storage-path task in progress; a validation-regex change belongs
+in its own diff.

--- a/feature/login/ui/src/androidMain/kotlin/com/grappim/taigamobile/feature/login/ui/GithubOAuthWebViewDialog.android.kt
+++ b/feature/login/ui/src/androidMain/kotlin/com/grappim/taigamobile/feature/login/ui/GithubOAuthWebViewDialog.android.kt
@@ -42,3 +42,5 @@ actual fun GithubOAuthWebViewDialog(url: String, onCodeReceive: (String) -> Unit
         )
     }
 }
+
+actual fun isGithubOAuthSupported(): Boolean = true

--- a/feature/login/ui/src/commonMain/kotlin/com/grappim/taigamobile/feature/login/ui/GithubOAuthWebViewDialog.kt
+++ b/feature/login/ui/src/commonMain/kotlin/com/grappim/taigamobile/feature/login/ui/GithubOAuthWebViewDialog.kt
@@ -4,3 +4,5 @@ import androidx.compose.runtime.Composable
 
 @Composable
 expect fun GithubOAuthWebViewDialog(url: String, onCodeReceive: (String) -> Unit, onDismiss: () -> Unit)
+
+expect fun isGithubOAuthSupported(): Boolean

--- a/feature/login/ui/src/commonMain/kotlin/com/grappim/taigamobile/feature/login/ui/LoginScreen.kt
+++ b/feature/login/ui/src/commonMain/kotlin/com/grappim/taigamobile/feature/login/ui/LoginScreen.kt
@@ -247,37 +247,39 @@ fun LoginScreenContent(state: LoginState, modifier: Modifier = Modifier) {
                 Text(stringResource(RString.login_ldap))
             }
 
-            Spacer(Modifier.height(8.dp))
+            if (isGithubOAuthSupported()) {
+                Spacer(Modifier.height(8.dp))
 
-            OutlinedButton(
-                onClick = { state.onGithubLoginClick() }
-            ) {
-                Text(stringResource(RString.login_github))
+                OutlinedButton(
+                    onClick = { state.onGithubLoginClick() }
+                ) {
+                    Text(stringResource(RString.login_github))
+                }
+
+                Spacer(Modifier.height(4.dp))
+
+                Text(
+                    text = stringResource(RString.login_github_server_required),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = if (state.isServerInputError) {
+                        MaterialTheme.colorScheme.error
+                    } else {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    },
+                    modifier = Modifier.padding(horizontal = 40.dp)
+                )
+
+                Text(
+                    text = stringResource(RString.login_github_setup_guide),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier
+                        .padding(top = 2.dp)
+                        .clickable {
+                            uriHandler.openUri(githubSetupGuideUrl)
+                        }
+                )
             }
-
-            Spacer(Modifier.height(4.dp))
-
-            Text(
-                text = stringResource(RString.login_github_server_required),
-                style = MaterialTheme.typography.bodySmall,
-                color = if (state.isServerInputError) {
-                    MaterialTheme.colorScheme.error
-                } else {
-                    MaterialTheme.colorScheme.onSurfaceVariant
-                },
-                modifier = Modifier.padding(horizontal = 40.dp)
-            )
-
-            Text(
-                text = stringResource(RString.login_github_setup_guide),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier
-                    .padding(top = 2.dp)
-                    .clickable {
-                        uriHandler.openUri(githubSetupGuideUrl)
-                    }
-            )
         }
     }
 }

--- a/feature/login/ui/src/iosMain/kotlin/com/grappim/taigamobile/feature/login/ui/GithubOAuthWebViewDialog.ios.kt
+++ b/feature/login/ui/src/iosMain/kotlin/com/grappim/taigamobile/feature/login/ui/GithubOAuthWebViewDialog.ios.kt
@@ -4,3 +4,5 @@ import androidx.compose.runtime.Composable
 
 @Composable
 actual fun GithubOAuthWebViewDialog(url: String, onCodeReceive: (String) -> Unit, onDismiss: () -> Unit) = Unit
+
+actual fun isGithubOAuthSupported(): Boolean = false

--- a/feature/login/ui/src/jvmMain/kotlin/com/grappim/taigamobile/feature/login/ui/GithubOAuthWebViewDialog.jvm.kt
+++ b/feature/login/ui/src/jvmMain/kotlin/com/grappim/taigamobile/feature/login/ui/GithubOAuthWebViewDialog.jvm.kt
@@ -4,3 +4,5 @@ import androidx.compose.runtime.Composable
 
 @Composable
 actual fun GithubOAuthWebViewDialog(url: String, onCodeReceive: (String) -> Unit, onDismiss: () -> Unit) = Unit
+
+actual fun isGithubOAuthSupported(): Boolean = false

--- a/testing/src/commonMain/kotlin/com/grappim/taigamobile/testing/dao/FakeProjectDao.kt
+++ b/testing/src/commonMain/kotlin/com/grappim/taigamobile/testing/dao/FakeProjectDao.kt
@@ -34,4 +34,6 @@ class FakeProjectDao : ProjectDao {
         getProjectByIdFlowCalls += id
         return flowOf(*(projectFlowsById[id] ?: emptyList()).toTypedArray())
     }
+
+    override suspend fun deleteAll() = error("not used in this test")
 }

--- a/testing/src/commonMain/kotlin/com/grappim/taigamobile/testing/dao/FakeSprintDao.kt
+++ b/testing/src/commonMain/kotlin/com/grappim/taigamobile/testing/dao/FakeSprintDao.kt
@@ -38,4 +38,6 @@ class FakeSprintDao : SprintDao {
         deleteByProjectIdAndClosedThrows?.let { throw it }
         deletedByProjectIdAndClosed = projectId to isClosed
     }
+
+    override suspend fun deleteAll() = error("not used in this test")
 }

--- a/testing/src/commonMain/kotlin/com/grappim/taigamobile/testing/dao/FakeWorkItemDao.kt
+++ b/testing/src/commonMain/kotlin/com/grappim/taigamobile/testing/dao/FakeWorkItemDao.kt
@@ -69,4 +69,6 @@ class FakeWorkItemDao : WorkItemDao {
         projectId: Long,
         taskType: CommonTaskType
     ): PagingSource<Int, WorkItemEntity> = error("not used in this test")
+
+    override suspend fun deleteAll() = error("not used in this test")
 }


### PR DESCRIPTION
Packaging is broken (bad icon path since PR #221, verified by actually running packageDeb) and JVM storage writes to java.io.tmpdir instead of a persistent dir, plus no CI ever exercises the desktop target. Splits the fix into one-task-per-session units, same shape as the testing plan.

### Be sure to run locally
1. `./gradlew ktlintFormat`
2. `./gradlew jvmTest`
3. `./gradlew :androidApp:assembleFdroidDebug`

### Describe your changes

<!-- Thank you for your Pull Request. Please provide a description above. -->

### Additional Information

<!-- Add any other context about the Pull Request here. -->
