### PR TITLE
ci: add guardrails workflow and Android lint check

### DIFF
--- a/.github/scripts/check-guardrails.sh
+++ b/.github/scripts/check-guardrails.sh
@@ -29,7 +29,11 @@ TRIPWIRE_PATHS=(
 
 failed=0
 
-for sha in $(git rev-list --reverse "$RANGE"); do
+# --no-merges: on a pull_request run, actions/checkout defaults to the synthetic
+# refs/pull/N/merge commit, which carries the PR's whole diff under an auto-generated
+# message that can never carry a Gate-change: trailer. Skipping merges means only the
+# real, author-written commits — which can carry the trailer — are checked.
+for sha in $(git rev-list --reverse --no-merges "$RANGE"); do
   base="$(git rev-parse --verify --quiet "${sha}^" || echo "$EMPTY_TREE")"
   subject="$(git log -1 --format=%s "$sha")"
   reasons=()

--- a/.github/scripts/check-guardrails.sh
+++ b/.github/scripts/check-guardrails.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Fails a commit that weakens one of this repo's gates without saying so out loud.
+#
+# The gates (detekt, ktlint, the tests, the Kover floor, CI) constrain the code a session writes.
+# Nothing constrains a session from widening a gate so its own step passes. This does not prevent
+# that — it makes it impossible to do quietly: a commit that trips a wire has to carry a
+#
+#   Gate-change: <what was widened, and why>
+#
+# line in its message. The wires are chosen so ordinary feature work never touches them.
+#
+# Usage: check-guardrails.sh [<range>]     (default HEAD~1..HEAD)
+
+set -euo pipefail
+
+MARKER='Gate-change:'
+EMPTY_TREE='4b825dc642cb6eb9a060e54bf8d69288fbee4904'
+RANGE="${1:-HEAD~1..HEAD}"
+
+# Files that ordinary feature work has no reason to touch: the build's own rules.
+TRIPWIRE_PATHS=(
+  '.github/'
+  'build-logic/'
+  'config/detekt/'
+  '.editorconfig'
+  'gradle/libs.versions.toml'
+)
+
+failed=0
+
+for sha in $(git rev-list --reverse "$RANGE"); do
+  base="$(git rev-parse --verify --quiet "${sha}^" || echo "$EMPTY_TREE")"
+  subject="$(git log -1 --format=%s "$sha")"
+  reasons=()
+
+  while IFS= read -r file; do
+    [ -n "$file" ] || continue
+    for wire in "${TRIPWIRE_PATHS[@]}"; do
+      case "$wire" in
+        */) [ "${file##"$wire"}" != "$file" ] && reasons+=("touches $file") ;;
+        *)  [ "$file" = "$wire" ] && reasons+=("touches $file") ;;
+      esac
+    done
+  done <<<"$(git diff --name-only "$base" "$sha")"
+
+  added="$(git diff "$base" "$sha" -- '*.kt' '*.kts' | grep '^+' | grep -v '^+++' || true)"
+  grep -qE '@Ignore\b' <<<"$added" && reasons+=('adds an @Ignore — a test that no longer runs')
+  grep -qE '@Suppress\(' <<<"$added" && reasons+=('adds a @Suppress — a lint rule that no longer applies')
+
+  [ ${#reasons[@]} -eq 0 ] && continue
+
+  if git log -1 --format=%B "$sha" | grep -q "^${MARKER}"; then
+    echo "ok   ${sha:0:7} ${subject} — declared, ${#reasons[@]} tripwire(s)"
+    continue
+  fi
+
+  failed=1
+  echo
+  echo "FAIL ${sha:0:7} ${subject}"
+  printf '       - %s\n' "${reasons[@]}"
+done
+
+if [ "$failed" -ne 0 ]; then
+  cat <<EOF
+
+A commit above changes something that decides whether other commits pass.
+That is allowed — silently is not. Say so in the commit message:
+
+    ${MARKER} <what was widened, and why>
+
+If the change was not deliberate, reverting that file is the other way out.
+EOF
+  exit 1
+fi
+
+echo "Guardrails: nothing tripped in ${RANGE}."

--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Run Ktlint
         run: ./gradlew ktlintCheck
 
+      - name: Run Android/Compose lint
+        run: ./gradlew :androidApp:lintFdroidDebug :androidApp:lintGplayDebug -PgplayBuild
+
       # koverXmlReport only runs jvmTest for the modules aggregated in the root
       # build.gradle.kts kover {} block, so a test in a non-aggregated module
       # (:testing, :uikit, :tools:*) would never execute. This step runs every

--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -45,6 +45,7 @@ jobs:
         TAIGA_STORE_PASS_D: ${{ secrets.TAIGA_STORE_PASS_D }}
         TAIGA_ALIAS_D: ${{ secrets.TAIGA_ALIAS_D }}
         ENCODED_STRING_D: ${{ secrets.TAIGA_KEYSTORE_D }}
+        ENCODED_GOOGLE_SERVICES_GPLAY: ${{ secrets.GOOGLE_SERVICES_GPLAY }}
 
     steps:
       - name: Check out the repo
@@ -52,6 +53,9 @@ jobs:
 
       - name: Setup Android Environment
         uses: ./.github/actions/android-setup-composite-action
+
+      - name: Restore google-services.json
+        run: echo $ENCODED_GOOGLE_SERVICES_GPLAY | base64 -d > ./androidApp/src/gplay/google-services.json
 
       - name: Run Detekt
         run: ./gradlew detekt

--- a/.github/workflows/guardrails.yml
+++ b/.github/workflows/guardrails.yml
@@ -1,0 +1,58 @@
+name: Guardrails
+
+# Deliberately no `paths-ignore`, unlike build.yml/code_analysis.yml: a commit that only edits
+# CLAUDE.md produces no CI run at all, and that file decides what every later session is allowed
+# to do.
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - dev
+      - master
+  pull_request:
+    branches:
+      - dev
+      - master
+
+concurrency:
+  group: guardrails-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  guardrails:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Work out the range to check
+        id: range
+        run: |
+          if [ "${{ github.event_name }}" = 'pull_request' ]; then
+            range="origin/${{ github.base_ref }}..HEAD"
+          else
+            before='${{ github.event.before }}'
+            if ! git cat-file -e "${before}^{commit}" 2>/dev/null; then
+              before="$(git rev-parse --verify --quiet 'HEAD^' || echo '')"
+            fi
+            range="${before:+${before}..}HEAD"
+          fi
+          echo "range=${range}" >> "$GITHUB_OUTPUT"
+          echo "Checking ${range}"
+
+      - name: Check the gate tripwires
+        run: .github/scripts/check-guardrails.sh '${{ steps.range.outputs.range }}'
+
+      - name: Validate workflow YAML syntax
+        run: |
+          npm install --no-save js-yaml
+          for f in .github/workflows/*.yml; do
+            echo "Checking ${f}"
+            node -e "require('js-yaml').load(require('fs').readFileSync('${f}', 'utf8'))"
+          done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -318,6 +318,20 @@ from a previous run under different env vars. Confirmed the same trap for `-P` f
 reports at all until `--rerun-tasks` forced re-execution (see
 [docs/compose/stability-reports.md](docs/compose/stability-reports.md)).
 
+## CI Guardrails
+
+`.github/workflows/guardrails.yml` (+ `.github/scripts/check-guardrails.sh`) fails a commit that
+touches `.github/`, `build-logic/`, `config/detekt/`, `.editorconfig` or `gradle/libs.versions.toml`,
+or that adds a new `@Ignore`/`@Suppress`, unless the commit message carries a line:
+
+```
+Gate-change: what was widened, and why
+```
+
+This doesn't prevent widening a gate — it makes doing so silently impossible. It runs with no
+`paths-ignore`, unlike `build.yml`/`code_analysis.yml`, so a CLAUDE.md-only commit is still checked.
+Run it locally before committing: `.github/scripts/check-guardrails.sh HEAD~1..HEAD`.
+
 ## Skills & Agents
 
 `.claude/agents/` in this repo holds only the project-specific agents: **testing** and

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,6 +11,12 @@ kotlin.daemon.jvm.options=-XX:+UseParallelGC -Xmx4096m -XX:MaxMetaspaceSize=768m
 org.gradle.parallel=true
 org.gradle.warning.mode=summary
 
+# Retry transient repository failures (e.g. Maven Central 429 rate-limiting, seen in CI)
+# instead of failing the build outright. Defaults are 3 tentatives / 500ms initial backoff;
+# Gradle backs off exponentially between attempts.
+systemProp.org.gradle.internal.repository.max.tentatives=5
+systemProp.org.gradle.internal.repository.initial.backoff=1000
+
 #debug.local.host=http://10.0.2.2:9000
 debug.local.host=http://192.168.0.248:9000
 


### PR DESCRIPTION
## Summary
- Port the `guardrails.yml` tripwire from wallosmobile: fails a commit that touches a gate-defining path (`build-logic/`, `config/detekt/`, `gradle/libs.versions.toml`, `.editorconfig`, `.github/`) or adds a new `@Ignore`/`@Suppress`, unless the commit message carries a `Gate-change: <reason>` trailer. Runs with no `paths-ignore` so a CLAUDE.md-only commit is still checked.
- Adapted `check-guardrails.sh` for this repo: dropped the `## Non-negotiables`/`CHECKLIST.md` counters from the original since neither exists here.
- Added `lintFdroidDebug`/`lintGplayDebug` to `code_analysis.yml` — Android/Compose lint was never run in CI here, unlike wallosmobile's `ci.yml`. Both variants currently pass clean locally.

## Test plan
- [x] `check-guardrails.sh` run locally against recent history — correctly flags real gate-touching commits (e.g. `build-logic/` changes, `gradle/libs.versions.toml` bumps)
- [x] All workflow YAML files, including the new one, validated with `js-yaml`
- [x] `./gradlew :androidApp:lintFdroidDebug` — BUILD SUCCESSFUL
- [x] `./gradlew :androidApp:lintGplayDebug -PgplayBuild` — BUILD SUCCESSFUL
- [ ] CI run on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)