### PR TITLE
fix: strip host info from raw network exceptions before Crashlytics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -455,6 +455,12 @@ historical record of how the register was built — `masvs.md` itself is the cur
 
 - Never swallow exceptions silently. Every `catch` block must at least log the exception:
   `logcat(LogPriority.ERROR, throwable = e) { "what failed" }`.
+- `CrashlyticsTree` forwards every `logcat(priority = ERROR, throwable = ...)` call verbatim to
+  Firebase, including the throwable's raw `.message`. Before logging a *raw* (unmapped) exception
+  from a network/parsing/IO boundary at that priority, check whether its message can carry
+  sensitive data (a hostname, a response body) — see `core/api/.../ExceptionSanitization.kt` and
+  `docs/security/masvs.md`'s MASVS-PRIVACY-3 note for the pattern and the audit
+  (`grep -rn "LogPriority.ERROR"` + `throwable =` is the full surface).
 
 ## Compose / Platform Rules
 

--- a/core/api/src/commonMain/kotlin/com/grappim/taigamobile/core/api/ExceptionSanitization.kt
+++ b/core/api/src/commonMain/kotlin/com/grappim/taigamobile/core/api/ExceptionSanitization.kt
@@ -1,0 +1,4 @@
+package com.grappim.taigamobile.core.api
+
+// Network failures (DNS/connect/TLS) often embed the server hostname in their message; strip it before Crashlytics.
+internal fun Throwable.sanitizedForCrashReporting(): Throwable = Exception(this::class.simpleName ?: "UnknownException")

--- a/core/api/src/commonMain/kotlin/com/grappim/taigamobile/core/api/TokenRefreshPlugin.kt
+++ b/core/api/src/commonMain/kotlin/com/grappim/taigamobile/core/api/TokenRefreshPlugin.kt
@@ -103,7 +103,7 @@ class TokenRefreshPlugin(private val authStorage: AuthStorage, private val token
                         logcat(
                             priority = LogPriority.ERROR,
                             tag = "TokenRefreshPlugin",
-                            throwable = e
+                            throwable = e.sanitizedForCrashReporting()
                         ) { "Token refresh failed" }
                         plugin.tokenRefresher.logout()
                         return@withLock response

--- a/core/api/src/commonMain/kotlin/com/grappim/taigamobile/core/api/errors/ErrorMappingPlugin.kt
+++ b/core/api/src/commonMain/kotlin/com/grappim/taigamobile/core/api/errors/ErrorMappingPlugin.kt
@@ -1,5 +1,6 @@
 package com.grappim.taigamobile.core.api.errors
 
+import com.grappim.taigamobile.core.api.sanitizedForCrashReporting
 import com.grappim.taigamobile.core.domain.NetworkException
 import com.grappim.taigamobile.core.domain.ProjectLimitInfo
 import com.grappim.taigamobile.core.logger.LogPriority
@@ -62,7 +63,11 @@ class ErrorMappingPlugin(
                 } catch (e: NetworkException) {
                     throw e
                 } catch (e: Exception) {
-                    logcat(priority = LogPriority.ERROR, tag = "ErrorMappingPlugin", throwable = e) {
+                    logcat(
+                        priority = LogPriority.ERROR,
+                        tag = "ErrorMappingPlugin",
+                        throwable = e.sanitizedForCrashReporting()
+                    ) {
                         "Request failed"
                     }
                     throw plugin.networkErrorMapper.mapToNetworkException(e)

--- a/core/api/src/commonMain/kotlin/com/grappim/taigamobile/core/api/errors/ErrorResponseParser.kt
+++ b/core/api/src/commonMain/kotlin/com/grappim/taigamobile/core/api/errors/ErrorResponseParser.kt
@@ -1,6 +1,7 @@
 package com.grappim.taigamobile.core.api.errors
 
 import com.grappim.taigamobile.core.api.HttpJson
+import com.grappim.taigamobile.core.api.sanitizedForCrashReporting
 import com.grappim.taigamobile.core.domain.ProjectLimitInfo
 import com.grappim.taigamobile.core.domain.TaigaErrorDetails
 import com.grappim.taigamobile.core.logger.LogPriority
@@ -28,7 +29,7 @@ class ErrorResponseParser(@param:HttpJson private val json: Json) {
             parseValidationError(errorBody, statusCode)
         }
     } catch (e: Exception) {
-        logcat(priority = LogPriority.ERROR, tag = "ErrorMappingPlugin", throwable = e) {
+        logcat(priority = LogPriority.ERROR, tag = "ErrorMappingPlugin", throwable = e.sanitizedForCrashReporting()) {
             "Failed to parse error response"
         }
         parseValidationError(errorBody, statusCode)

--- a/core/api/src/commonTest/kotlin/com/grappim/taigamobile/core/api/ExceptionSanitizationTest.kt
+++ b/core/api/src/commonTest/kotlin/com/grappim/taigamobile/core/api/ExceptionSanitizationTest.kt
@@ -1,0 +1,26 @@
+package com.grappim.taigamobile.core.api
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class ExceptionSanitizationTest {
+
+    @Test
+    fun `sanitizedForCrashReporting replaces the message with the exception class name`() {
+        val original = RuntimeException("""Unable to resolve host "myserver.example.com"""")
+
+        val sanitized = original.sanitizedForCrashReporting()
+
+        assertEquals("RuntimeException", sanitized.message)
+    }
+
+    @Test
+    fun `sanitizedForCrashReporting drops the original message text`() {
+        val original = IllegalStateException("connection refused to myserver.example.com:443")
+
+        val sanitized = original.sanitizedForCrashReporting()
+
+        assertFalse(sanitized.message.orEmpty().contains("myserver.example.com"))
+    }
+}

--- a/core/api/src/commonTest/kotlin/com/grappim/taigamobile/core/api/errors/ErrorResponseParserTest.kt
+++ b/core/api/src/commonTest/kotlin/com/grappim/taigamobile/core/api/errors/ErrorResponseParserTest.kt
@@ -5,7 +5,9 @@ import kotlinx.serialization.json.Json
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFails
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class ErrorResponseParserTest {
 
@@ -96,6 +98,17 @@ class ErrorResponseParserTest {
         val result = sut.parseErrorResponse(body, 500, null)
 
         assertNull(result)
+    }
+
+    @Test
+    fun `decoding a malformed error body echoes the raw body in the exception message`() {
+        // kotlinx.serialization embeds the raw input in JsonDecodingException — that's the server's response body.
+        val marker = "s3nsitive-marker-value"
+        val malformedBody = """{"_error_message":"$marker"""
+
+        val exception = assertFails { json.decodeFromString<TaigaErrorResponse>(malformedBody) }
+
+        assertTrue(exception.message.orEmpty().contains(marker))
     }
 
     @Test

--- a/core/storage/src/jvmTest/kotlin/com/grappim/taigamobile/core/storage/auth/CipherExceptionMessageProbeTest.kt
+++ b/core/storage/src/jvmTest/kotlin/com/grappim/taigamobile/core/storage/auth/CipherExceptionMessageProbeTest.kt
@@ -1,0 +1,41 @@
+package com.grappim.taigamobile.core.storage.auth
+
+import java.security.GeneralSecurityException
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.spec.GCMParameterSpec
+import kotlin.io.encoding.Base64
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+
+// Probes AndroidKeystoreTokenCipher's ERROR-logged exception types (AndroidKeyStore itself isn't available on the JVM).
+class CipherExceptionMessageProbeTest {
+
+    private val marker = "s3nsitive-plaintext-token-marker"
+
+    @Test
+    fun `GCM tag mismatch exception message does not contain the plaintext`() {
+        val key = KeyGenerator.getInstance("AES").apply { init(256) }.generateKey()
+        val iv = ByteArray(12)
+        val encryptCipher = Cipher.getInstance("AES/GCM/NoPadding")
+        encryptCipher.init(Cipher.ENCRYPT_MODE, key, GCMParameterSpec(128, iv))
+        val ciphertext = encryptCipher.doFinal(marker.encodeToByteArray())
+        ciphertext[0] = (ciphertext[0].toInt() xor 0xFF).toByte()
+
+        val decryptCipher = Cipher.getInstance("AES/GCM/NoPadding")
+        decryptCipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(128, iv))
+        val exception = assertFailsWith<GeneralSecurityException> { decryptCipher.doFinal(ciphertext) }
+
+        assertFalse(exception.message.orEmpty().contains(marker))
+    }
+
+    @Test
+    fun `Base64 decode failure exception message does not contain the raw input`() {
+        val invalidBase64 = "$marker!!!not-valid-base64###"
+
+        val exception = assertFailsWith<IllegalArgumentException> { Base64.decode(invalidBase64) }
+
+        assertFalse(exception.message.orEmpty().contains(marker))
+    }
+}

--- a/docs/security/masvs.md
+++ b/docs/security/masvs.md
@@ -192,6 +192,20 @@ client in this space — are outside what MASVS covers. Formal decision, task 7 
   `Crashlytics.isCrashlyticsCollectionEnabled` for real, not just a UI toggle with no backing effect.
   Recorded as an Accepted deviation, not a finding — default-on-but-disclosed-and-revocable is a
   documented bound, not silence.
+  **2026-08-13:** the "credentials/tokens/project content excluded" disclosure had a real gap, now
+  fixed. `CrashlyticsTree` (`androidApp/.../CrashlyticsTree.kt:7-13`) forwards any
+  `logcat(priority = ERROR, throwable = ...)` call straight to `Firebase.crashlytics.recordException()`,
+  and three `core/api` call sites passed a *raw*, unmapped exception on that path:
+  `ErrorMappingPlugin.kt` and `TokenRefreshPlugin.kt` (OkHttp/Ktor exceptions — `UnknownHostException`,
+  `ConnectException`, `SSLHandshakeException` — embed the target hostname in `.message`) and
+  `ErrorResponseParser.kt` (kotlinx.serialization's decode-failure exception embeds the raw JSON
+  input — the server's response body — confirmed by planting a marker string,
+  `ErrorResponseParserTest.kt`). Fixed with `Throwable.sanitizedForCrashReporting()`
+  (`core/api/.../ExceptionSanitization.kt`) at all three sites; the original exception is still used
+  unchanged for control flow (rethrow/mapping/logout). The two remaining `LogPriority.ERROR` +
+  throwable sites in the repo, `AndroidKeystoreTokenCipher.kt:48,51` (GCM tag-mismatch and
+  Base64-decode failures), were checked with a probe test against the real JDK exception types rather
+  than assumed safe — confirmed neither leaks the plaintext token. PR #354.
 - **MASVS-PRIVACY-1/2 both confirmed, not assumed trivial.** Permissions: `INTERNET` and
   `ACCESS_NETWORK_STATE` are the only two declared, and both have a real call site (grep-confirmed, see
   Accepted table). Identification: grepped for advertising-ID/analytics-SDK/fingerprinting call sites


### PR DESCRIPTION
## Summary
- `ErrorMappingPlugin` and `TokenRefreshPlugin` logged raw, unmapped network exceptions (`UnknownHostException`, `ConnectException`, `SSLHandshakeException`, etc.) at `LogPriority.ERROR` with a throwable, which `CrashlyticsTree` forwards to `Firebase.crashlytics.recordException()`.
- Those raw exceptions' `.message` routinely embeds the target hostname, so a DNS/connect/TLS failure while talking to a user's self-hosted Taiga server could leak that hostname to Crashlytics.
- Added `Throwable.sanitizedForCrashReporting()` (`core/api/.../ExceptionSanitization.kt`) which drops the exception message and keeps only the class name, and applied it at both call sites' `logcat(..., throwable = ...)` argument only — the original exception is still used unchanged for control flow (rethrow via `NetworkException` mapping / token-refresh logout).

## Test plan
- [x] `./gradlew :core:api:jvmTest --tests "com.grappim.taigamobile.core.api.*"` — passes, including new `ExceptionSanitizationTest`
- [x] `./gradlew jvmTest` (full suite) — passes
- [x] `./gradlew :core:api:ktlintCheck` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)