### PR TITLE
fix: narrow guardrails' libs.versions.toml wire to gate-relevant keys

### DIFF
--- a/.github/scripts/check-guardrails.sh
+++ b/.github/scripts/check-guardrails.sh
@@ -27,6 +27,21 @@ TRIPWIRE_PATHS=(
   'gradle/libs.versions.toml'
 )
 
+# gradle/libs.versions.toml is on the list above, but Renovate touches it constantly for
+# ordinary dependency bumps (ktor, coroutines, koin, ...) that don't decide whether anything
+# passes, and a bot-authored commit can never carry a Gate-change line. Only these version keys
+# actually govern a gate — detekt/ktlint/composeRules run the lint checks, kover backs the
+# koverVerify coverage floor, agp backs both AGP's own Android/Compose lint task and the KMP
+# build — so the wire below only fires when one of them is what changed, not on every version
+# bump in the file.
+GATE_VERSION_KEYS='^[+-](detekt|ktlint|composeRules|agp|kover)[[:space:]]*='
+
+# True if the diff for gradle/libs.versions.toml between $1 and $2 touches a gate-relevant key.
+libs_versions_touches_gate() {
+  git diff "$1" "$2" -- gradle/libs.versions.toml |
+    grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | grep -qE "$GATE_VERSION_KEYS"
+}
+
 failed=0
 
 # --no-merges: on a pull_request run, actions/checkout defaults to the synthetic
@@ -42,6 +57,11 @@ for sha in $(git rev-list --reverse --no-merges "$RANGE"); do
     [ -n "$file" ] || continue
     for wire in "${TRIPWIRE_PATHS[@]}"; do
       case "$wire" in
+        gradle/libs.versions.toml)
+          if [ "$file" = "$wire" ] && libs_versions_touches_gate "$base" "$sha"; then
+            reasons+=("touches $file (a gate-relevant version: detekt/ktlint/composeRules/agp/kover)")
+          fi
+          ;;
         */) [ "${file##"$wire"}" != "$file" ] && reasons+=("touches $file") ;;
         *)  [ "$file" = "$wire" ] && reasons+=("touches $file") ;;
       esac

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -321,8 +321,11 @@ reports at all until `--rerun-tasks` forced re-execution (see
 ## CI Guardrails
 
 `.github/workflows/guardrails.yml` (+ `.github/scripts/check-guardrails.sh`) fails a commit that
-touches `.github/`, `build-logic/`, `config/detekt/`, `.editorconfig` or `gradle/libs.versions.toml`,
-or that adds a new `@Ignore`/`@Suppress`, unless the commit message carries a line:
+touches `.github/`, `build-logic/`, `config/detekt/`, or `.editorconfig`; that touches
+`gradle/libs.versions.toml`'s `detekt`, `ktlint`, `composeRules`, `agp` or `kover` version keys
+specifically (a plain dependency bump — Renovate's usual PR — doesn't trip it, narrowed 2026-08-14
+after Renovate's own commits, which can never carry a `Gate-change:` line, failed guardrails on
+every PR); or that adds a new `@Ignore`/`@Suppress`, unless the commit message carries a line:
 
 ```
 Gate-change: what was widened, and why

--- a/docs/frictions.md
+++ b/docs/frictions.md
@@ -2,3 +2,9 @@
 
 Tooling friction hit during work, newest last. One line each. Promoted or fixed entries get
 deleted — see `finalize`.
+
+- 2026-08-14: every Renovate PR failed guardrails because the `gradle/libs.versions.toml` wire
+  fired on any touch to the file and a bot commit can never carry `Gate-change:`; fixed (ported
+  from wallosmobile) by narrowing the wire to `detekt`/`ktlint`/`composeRules`/`agp`/`kover` keys
+  only — verified against real commits `9d925e6b` (ksp bump, now passes) and `6f12f291` (detekt
+  bump, still correctly fails).


### PR DESCRIPTION
## Summary
- Every Renovate PR was failing `guardrails.yml`: the `gradle/libs.versions.toml` tripwire fired on *any* touch to the file, and a bot-authored commit can never carry the required `Gate-change:` line.
- Narrows the wire so only version keys that actually govern a gate — `detekt`, `ktlint`, `composeRules`, `agp`, `kover` — trip it. An ordinary dependency bump (ktor, coroutines, koin, firebase, ...) no longer trips guardrails; a gate-relevant version bump still does.
- Ported from an equivalent fix already landed in `wallosmobile` (commit `e38401b`), adapted to this repo's actual gate-governing keys (`kover` instead of `androidToolsLint`, which doesn't exist here as a separate catalog key).

## Test plan
- [x] `bash -n .github/scripts/check-guardrails.sh` — syntax check
- [x] Ran the updated script against real commit `9d925e6b` (Renovate ksp bump) — now passes
- [x] Ran the updated script against real commit `6f12f291` (Renovate detekt bump) — still correctly fails as gate-relevant
- [x] Ran the updated script against real commit `d497a81` (Renovate composeRules bump) — still correctly fails as gate-relevant
- [x] Self-check: `check-guardrails.sh HEAD~1..HEAD` on this PR's own commit passes (declared via `Gate-change:` trailer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)