### PR TITLE
docs(vm-lifecycle-hardening): ViewModel lifecycle & error-handling hardening

### DIFF
--- a/.claude/agents/testing.md
+++ b/.claude/agents/testing.md
@@ -309,6 +309,16 @@ example; see also the `TaskIdentifier` note under `WorkItemEditStateRepository`.
 ### ViewModel init loads data synchronously
 With `MainDispatcherRule` using `UnconfinedTestDispatcher`, `init { viewModelScope.launch { ... } }` completes before `createViewModel()` returns. Assert state directly after `createViewModel()` without `runTest`.
 
+### Reaching a target state without chaining setters
+Don't chain `onXChange`/`setX` calls to build up a multi-field state before the behaviour under
+test — the VM's own constructor inputs are already the seam: for a load-in-`init` VM, set the
+fake's return value to the *target* state directly (init copies it straight into `_state`); for a
+`SavedStateHandle`-restored VM (see `CreateTaskViewModel`'s `RestorableState`), pre-seed the handle
+with the target values instead of calling the setters. Confirmed 2026-08-29 investigating whether
+ViewModels needed a dedicated constructor-injected `initialState` param (the "OTOS" pattern from
+`docs/architecture/vm-lifecycle-hardening/IMPLEMENTATION_PLAN.md`) — every VM examined already had
+one of these two seams, so the extra param would only duplicate it.
+
 ### Channel / one-off events (Turbine)
 ```kotlin
 @Test

--- a/.claude/agents/testing.md
+++ b/.claude/agents/testing.md
@@ -422,6 +422,30 @@ fun `patchData should propagate api error`() = runTest {
   `CreateWorkItemUseCaseTest` and `GetProfileDataUseCaseTest` both do this with a local helper; if a
   third file needs it, promote it to `:testing`'s `TestUtils.kt`.
 
+### Asserting something was logged (`TaigaLogger`)
+
+To prove a `catch` block or a `CoroutineExceptionHandler` actually logs (CLAUDE.md's Error
+Handling rule) rather than swallowing silently, implement `TaigaLogger` inline in the test, call
+`TaigaLogger.install(it)`, exercise the code, then assert on the recorded `priority`/`throwable`.
+`TaigaLogger.uninstall()` in `@AfterTest` — it's a process-wide `@Volatile var`, so a leaked
+install bleeds into unrelated tests in the same JVM process (see gotcha 7 on shared test process
+state). First example: `core/async-kmp/src/commonTest/.../KmpCoroutinesModuleTest.kt`.
+
+```kotlin
+private class RecordingLogger : TaigaLogger {
+    var priority: LogPriority? = null
+    var throwable: Throwable? = null
+
+    override fun log(priority: LogPriority, tag: String?, throwable: Throwable?, message: () -> String) {
+        this.priority = priority
+        this.throwable = throwable
+    }
+}
+
+@AfterTest
+fun tearDown() = TaigaLogger.uninstall()
+```
+
 ### Ktor plugins and anything needing a real `HttpResponse`
 
 `ktor-client-mock` is in the catalog as `libs.ktor.client.mock`. Add it to the module's

--- a/.claude/templates/spec.md
+++ b/.claude/templates/spec.md
@@ -1,1 +1,0 @@
-../agentic-grappim/templates/spec.md

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,69 @@ jobs:
       - name: Assemble gradle gplay project
         run: ./gradlew :androidApp:assembleGplayDebug -PgplayBuild
 
+  apk-size-check:
+    runs-on: ubuntu-latest
+    env:
+        TAIGA_PATH_D: ${{ secrets.TAIGA_PATH_D }}
+        TAIGA_KEY_PASS_D: ${{ secrets.TAIGA_KEY_PASS_D }}
+        TAIGA_STORE_PASS_D: ${{ secrets.TAIGA_STORE_PASS_D }}
+        TAIGA_ALIAS_D: ${{ secrets.TAIGA_ALIAS_D }}
+        ENCODED_STRING_D: ${{ secrets.TAIGA_KEYSTORE_D }}
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v7
+
+      - name: Setup Android Environment
+        uses: ./.github/actions/android-setup-composite-action
+
+      - name: Restore taigamobilenova_debug.jks
+        run: echo $ENCODED_STRING_D | base64 -d > ./taigamobilenova_debug.jks
+
+      - name: Assemble fdroid debug (PR head)
+        run: ./gradlew :androidApp:assembleFdroidDebug
+
+      - name: Save PR head APK
+        run: |
+            mkdir -p apk-diff
+            cp androidApp/build/outputs/apk/fdroid/debug/app-fdroid-debug.apk apk-diff/head.apk
+
+      - name: Check out PR base (${{ github.event.pull_request.base.sha }})
+        run: |
+            git fetch --depth=1 origin ${{ github.event.pull_request.base.sha }}
+            git checkout ${{ github.event.pull_request.base.sha }}
+
+      - name: Assemble fdroid debug (base)
+        run: ./gradlew :androidApp:assembleFdroidDebug
+
+      - name: Save base APK
+        run: cp androidApp/build/outputs/apk/fdroid/debug/app-fdroid-debug.apk apk-diff/base.apk
+
+      - name: Diff APK size
+        id: diffuse
+        uses: usefulness/diffuse-action@v1
+        with:
+            old-file-path: apk-diff/base.apk
+            new-file-path: apk-diff/head.apk
+
+      - name: Find existing APK size comment
+        uses: peter-evans/find-comment@v4
+        id: fc
+        with:
+            issue-number: ${{ github.event.pull_request.number }}
+            comment-author: 'github-actions[bot]'
+            body-includes: '<!-- apk-size-diff -->'
+
+      - name: Comment APK size delta on PR
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+            comment-id: ${{ steps.fc.outputs.comment-id }}
+            issue-number: ${{ github.event.pull_request.number }}
+            edit-mode: replace
+            body: |
+                <!-- apk-size-diff -->
+                ${{ steps.diffuse.outputs.diff-gh-comment }}
+
   desktop-package:
     runs-on: ubuntu-latest
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -376,6 +376,17 @@ This doesn't prevent widening a gate — it makes doing so silently impossible. 
 `paths-ignore`, unlike `build.yml`/`code_analysis.yml`, so a CLAUDE.md-only commit is still checked.
 Run it locally before committing: `.github/scripts/check-guardrails.sh HEAD~1..HEAD`.
 
+**Validate a `.github/workflows/*.yml` edit locally before pushing** — `docker run --rm -v
+"$(pwd)":/repo -w /repo rhysd/actionlint:latest .github/workflows/<file>.yml` catches invalid
+expressions, unknown action inputs, and embeds shellcheck on `run:` blocks, none of which a plain
+YAML-syntax check (`python3 -c "import yaml; yaml.safe_load(...)"`) would catch. Confirmed
+2026-08-30 adding `build.yml`'s `apk-size-check` job.
+
+**A `pull_request`-triggered job's default shallow checkout doesn't have the base branch's commit
+object locally** — to build against the PR's merge-base (e.g. for a size/perf diff), fetch it
+explicitly: `git fetch --depth=1 origin ${{ github.event.pull_request.base.sha }}` before `git
+checkout` that sha. Confirmed 2026-08-30 in `build.yml`'s `apk-size-check` job.
+
 ## Multi-Session Work
 
 For any initiative that spans multiple sessions — a feature investigation, a redesign, a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,14 @@ and stop.
   the JVM/native actual doesn't declare it at all (confirmed via `javap` on the `room-runtime`
   artifacts). To clear all tables on JVM/iOS, add a no-arg `deleteAll()` `@Query` to each DAO instead.
 - `core/logger` — KMP logging facade (see Logging below); Timber backs it on Android only
+- The JetBrains AndroidX forks (`org.jetbrains.androidx.lifecycle`, `org.jetbrains.androidx.navigation3`,
+  `org.jetbrains.androidx.savedstate`) publish their real per-platform code under the **plain
+  upstream group id** (`androidx.lifecycle`, `androidx.navigation3`) with platform classifiers
+  (`-desktop`, `-iosarm64`, …) — the `org.jetbrains.androidx.*` coordinate is a thin Gradle Module
+  Metadata redirect with no real classes or sources of its own. Downloading a `org.jetbrains.androidx.*`
+  sources jar to read the implementation returns an empty `redirectCommonMain/EmptyRedirectRoot.kt`
+  stub; look under `androidx.*` instead. Confirmed 2026-08-29 chasing `lifecycle-viewmodel-savedstate`
+  and `lifecycle-viewmodel-navigation3` sources.
 
 **Convention Plugins** (in `build-logic/`):
 

--- a/build-logic/convention/src/main/kotlin/com/grappim/taigamobile.buildlogic/KmpCompose.kt
+++ b/build-logic/convention/src/main/kotlin/com/grappim/taigamobile.buildlogic/KmpCompose.kt
@@ -19,6 +19,7 @@ fun Project.configureKmpCompose() {
 
                 implementation(libs.findLibrary("jetbrains.lifecycle.runtime.compose").get())
                 implementation(libs.findLibrary("jetbrains.lifecycle.viewmodel.compose").get())
+                implementation(libs.findLibrary("jetbrains.lifecycle.viewmodel.savedstate").get())
 
                 implementation(libs.findLibrary("jetbrains.androidx.savedstate").get())
             }

--- a/composeApp/src/commonMain/kotlin/com/grappim/taigamobile/createtask/CreateTaskViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/grappim/taigamobile/createtask/CreateTaskViewModel.kt
@@ -1,5 +1,6 @@
 package com.grappim.taigamobile.createtask
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.grappim.taigamobile.core.domain.CommonTaskType
@@ -11,6 +12,7 @@ import com.grappim.taigamobile.strings.generated.resources.create_task
 import com.grappim.taigamobile.strings.generated.resources.create_userstory
 import com.grappim.taigamobile.strings.generated.resources.title_is_empty
 import com.grappim.taigamobile.utils.ui.NativeText
+import com.grappim.taigamobile.utils.ui.RestorableState
 import com.grappim.taigamobile.utils.ui.getErrorMessage
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -24,8 +26,11 @@ import org.koin.core.annotation.KoinViewModel
 @KoinViewModel
 class CreateTaskViewModel(
     @InjectedParam val route: CreateTaskNavDestination,
-    private val createWorkItemUseCase: CreateWorkItemUseCase
+    private val createWorkItemUseCase: CreateWorkItemUseCase,
+    savedStateHandle: SavedStateHandle
 ) : ViewModel() {
+
+    private val restorableState = RestorableState(savedStateHandle)
 
     private val _state = MutableStateFlow(
         CreateTaskState(
@@ -37,6 +42,8 @@ class CreateTaskViewModel(
                     CommonTaskType.Issue -> RString.create_issue
                 }
             ),
+            title = restorableState.restore(KEY_TITLE, ""),
+            description = restorableState.restore(KEY_DESCRIPTION, ""),
             setTitle = ::setTitle,
             setDescription = ::setDescription,
             onCreateTask = ::onCreateTask
@@ -97,14 +104,21 @@ class CreateTaskViewModel(
     }
 
     private fun setTitle(title: String) {
+        restorableState.save(KEY_TITLE, title)
         _state.update {
             it.copy(title = title)
         }
     }
 
     private fun setDescription(description: String) {
+        restorableState.save(KEY_DESCRIPTION, description)
         _state.update {
             it.copy(description = description)
         }
+    }
+
+    companion object {
+        private const val KEY_TITLE = "title"
+        private const val KEY_DESCRIPTION = "description"
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/grappim/taigamobile/main/MainNavHost.kt
+++ b/composeApp/src/commonMain/kotlin/com/grappim/taigamobile/main/MainNavHost.kt
@@ -67,14 +67,26 @@ fun MainNavHost(
     showSnackbar: (NativeText) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val screenReadySignal = LocalScreenReadySignal.current
     LaunchedEffect(initialNavState.isReady) {
+        // navigationState.currentKey is only still LoginNavDestination (the seed value) when
+        // nothing has restored a deeper back stack yet — on a process-death relaunch, Nav3 has
+        // already restored the saved stack by this point, and resetting here would wipe it.
         if (initialNavState.isReady) {
-            when (val dest = initialNavState.startDestination) {
-                is ProjectSelectorNavDestination ->
-                    navigator.navigateToProjectSelector(isFromLogin = dest.isFromLogin)
+            if (navigationState.currentKey == LoginNavDestination) {
+                when (val dest = initialNavState.startDestination) {
+                    is ProjectSelectorNavDestination ->
+                        navigator.navigateToProjectSelector(isFromLogin = dest.isFromLogin)
 
-                is DashboardNavDestination ->
-                    navigator.navigateToDashboardAsTopDestination()
+                    is DashboardNavDestination ->
+                        navigator.navigateToDashboardAsTopDestination()
+                }
+            } else {
+                // A deeper back stack already restored: the correct screen is already on
+                // screen, so there's no Login-flash risk to wait out — the per-entry
+                // signalReady() calls below only cover the Login/ProjectSelector/Dashboard
+                // landing case.
+                screenReadySignal.signalReady()
             }
         }
     }

--- a/composeApp/src/commonTest/kotlin/com/grappim/taigamobile/createtask/CreateTaskViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/grappim/taigamobile/createtask/CreateTaskViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.grappim.taigamobile.createtask
 
+import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.grappim.taigamobile.core.domain.CommonTaskType
 import com.grappim.taigamobile.strings.RString
@@ -56,7 +57,8 @@ internal class CreateTaskViewModelTest {
         parentId: Long? = this.parentId,
         sprintId: Long? = this.sprintId,
         statusId: Long? = this.statusId,
-        swimlaneId: Long? = this.swimlaneId
+        swimlaneId: Long? = this.swimlaneId,
+        savedStateHandle: SavedStateHandle = SavedStateHandle()
     ) {
         sut = CreateTaskViewModel(
             route = CreateTaskNavDestination(
@@ -71,7 +73,8 @@ internal class CreateTaskViewModelTest {
                 issuesRepository = issuesRepository,
                 userStoriesRepository = userStoriesRepository,
                 workItemRepository = workItemRepository
-            )
+            ),
+            savedStateHandle = savedStateHandle
         )
     }
 
@@ -226,6 +229,44 @@ internal class CreateTaskViewModelTest {
         val call = userStoriesRepository.createUserStoryCalls.single()
         assertEquals(statusId, call.status)
         assertEquals(swimlaneId, call.swimlane)
+    }
+
+    // --- process-death restoration ---
+
+    @Test
+    fun `initial state - restores title and description from a prior SavedStateHandle`() = runTest {
+        val restoredTitle = getRandomString()
+        val restoredDescription = getRandomString()
+        val savedStateHandle = SavedStateHandle(
+            mapOf("title" to restoredTitle, "description" to restoredDescription)
+        )
+
+        createViewModel(savedStateHandle = savedStateHandle)
+
+        assertEquals(restoredTitle, sut.state.value.title)
+        assertEquals(restoredDescription, sut.state.value.description)
+    }
+
+    @Test
+    fun `setTitle - persists the new value to the SavedStateHandle`() = runTest {
+        val savedStateHandle = SavedStateHandle()
+        createViewModel(savedStateHandle = savedStateHandle)
+        val title = getRandomString()
+
+        sut.state.value.setTitle(title)
+
+        assertEquals(title, savedStateHandle.get<String>("title"))
+    }
+
+    @Test
+    fun `setDescription - persists the new value to the SavedStateHandle`() = runTest {
+        val savedStateHandle = SavedStateHandle()
+        createViewModel(savedStateHandle = savedStateHandle)
+        val description = getRandomString()
+
+        sut.state.value.setDescription(description)
+
+        assertEquals(description, savedStateHandle.get<String>("description"))
     }
 
     // --- onCreateTask: failure ---

--- a/composeApp/src/commonTest/kotlin/com/grappim/taigamobile/createtask/CreateTaskViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/grappim/taigamobile/createtask/CreateTaskViewModelTest.kt
@@ -178,13 +178,20 @@ internal class CreateTaskViewModelTest {
 
     // --- onCreateTask: success ---
 
+    /**
+     * State-init restores title/description from `savedStateHandle` (see the process-death
+     * restoration tests below) — pre-seeding it here reaches the target input in one step, with
+     * no `setTitle`/`setDescription` chain needed.
+     */
     @Test
     fun `onCreateTask - success - trims input, passes route arguments and emits creationResult`() = runTest {
         val created = getWorkItem()
         tasksRepository.createTaskResult = created
-        createViewModel()
-        sut.state.value.setTitle("  a title  ")
-        sut.state.value.setDescription("  a description  ")
+        createViewModel(
+            savedStateHandle = SavedStateHandle(
+                mapOf("title" to "  a title  ", "description" to "  a description  ")
+            )
+        )
 
         // `_creationResult` is a rendezvous channel, so the send only completes while collected.
         sut.creationResult.test {

--- a/composeApp/src/jvmTest/kotlin/com/grappim/taigamobile/di/KoinGraphTest.kt
+++ b/composeApp/src/jvmTest/kotlin/com/grappim/taigamobile/di/KoinGraphTest.kt
@@ -43,6 +43,14 @@ import kotlin.test.assertTrue
  * - **Nullable and lazy parameters.** A `T?` parameter resolves via `getOrNull()` and is silently
  *   null when unbound; a `Lazy<T>` resolves on first access, which never happens here. Neither
  *   raises, so neither fails this test.
+ * - **Any constructor parameter after the first one Koin can't resolve.** Kotlin evaluates
+ *   constructor arguments left to right, so a route-taking `@InjectedParam` ViewModel throws
+ *   `DefinitionParameterException` on its first (route) parameter and never evaluates the rest —
+ *   a `SavedStateHandle` parameter declared after `route`, for instance, is never actually
+ *   exercised by this test even though it shows up in the same tolerated "resolved their
+ *   dependencies but threw" bucket. Confirmed 2026-08-29 adding `SavedStateHandle` to
+ *   `CreateTaskViewModel`: this test's `constructionFailures` output was identical before and
+ *   after, proving nothing either way about the new parameter.
  *
  * ## Why constructor failures are tolerated
  *

--- a/core/async-kmp/src/commonMain/kotlin/com/grappim/taigamobile/core/asynckmp/KmpCorotuinesModule.kt
+++ b/core/async-kmp/src/commonMain/kotlin/com/grappim/taigamobile/core/asynckmp/KmpCorotuinesModule.kt
@@ -1,6 +1,9 @@
 package com.grappim.taigamobile.core.asynckmp
 
+import com.grappim.taigamobile.core.logger.LogPriority
+import com.grappim.taigamobile.core.logger.logcat
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
@@ -31,6 +34,10 @@ annotation class MainDispatcher
 @Qualifier
 annotation class MainImmediateDispatcher
 
+private val applicationScopeExceptionHandler = CoroutineExceptionHandler { _, throwable ->
+    logcat(LogPriority.ERROR, throwable = throwable) { "Unhandled exception on ApplicationScope" }
+}
+
 @Module
 @Configuration
 @ComponentScan("com.grappim.taigamobile.core.asynckmp")
@@ -44,7 +51,7 @@ class KmpCoroutinesModule {
 
     @[Single ApplicationScope]
     fun provideApplicationScope(@DefaultDispatcher defaultDispatcher: CoroutineDispatcher): CoroutineScope =
-        CoroutineScope(SupervisorJob() + defaultDispatcher)
+        CoroutineScope(SupervisorJob() + defaultDispatcher + applicationScopeExceptionHandler)
 
     @[Single MainDispatcher]
     fun providesMainDispatcher(): CoroutineDispatcher = Dispatchers.Main

--- a/core/async-kmp/src/commonTest/kotlin/com/grappim/taigamobile/core/asynckmp/KmpCoroutinesModuleTest.kt
+++ b/core/async-kmp/src/commonTest/kotlin/com/grappim/taigamobile/core/asynckmp/KmpCoroutinesModuleTest.kt
@@ -1,0 +1,47 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.grappim.taigamobile.core.asynckmp
+
+import com.grappim.taigamobile.core.logger.LogPriority
+import com.grappim.taigamobile.core.logger.TaigaLogger
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+internal class KmpCoroutinesModuleTest {
+
+    private class RecordingLogger : TaigaLogger {
+        var priority: LogPriority? = null
+        var throwable: Throwable? = null
+
+        override fun log(priority: LogPriority, tag: String?, throwable: Throwable?, message: () -> String) {
+            this.priority = priority
+            this.throwable = throwable
+        }
+    }
+
+    private val sut = KmpCoroutinesModule()
+
+    @AfterTest
+    fun tearDown() {
+        TaigaLogger.uninstall()
+    }
+
+    @Test
+    fun `exception thrown on ApplicationScope is logged, not propagated`() = runTest {
+        val recordingLogger = RecordingLogger()
+        TaigaLogger.install(recordingLogger)
+        val exception = IllegalStateException("boom")
+        val scope = sut.provideApplicationScope(UnconfinedTestDispatcher(testScheduler))
+
+        scope.launch { throw exception }
+
+        assertEquals(LogPriority.ERROR, recordingLogger.priority)
+        assertSame(exception, recordingLogger.throwable)
+    }
+}

--- a/docs/EMULATOR_TESTING.md
+++ b/docs/EMULATOR_TESTING.md
@@ -69,6 +69,18 @@ technique lives in the skill itself, not here — this file is only what's true 
   all | grep "default.*10.0.2.2"` before retrying the app. Not seen on `Medium_Phone_API_36.1` (route
   present from first boot) — may be specific to `Medium_Tablet`'s virtio-wifi network backend
   (`ro.boot.qemu.virtiowifi=1`) vs. the phone image's classic SLIRP/eth0 networking.
+- **The Nav3 back stack does not survive a real process kill.** Confirmed 2026-08-29 verifying
+  vm-lifecycle-hardening checklist step 2 (`CreateTaskViewModel`'s new `SavedStateHandle`
+  restoration): logged in, navigated Backlog → New user story, typed distinct title/description,
+  backgrounded (`KEYCODE_HOME`) and killed the process (`am kill`, confirmed dead via `ps`), then
+  relaunched onto the same task (`am start -n`, `sz=1` in `dumpsys activity activities` — a genuine
+  restore, not a fresh activity). The app landed on **Dashboard** (its post-login start
+  destination), not back on the Create Task screen — despite the user still being logged in. This
+  means any per-ViewModel `SavedStateHandle` restoration is currently inert in practice: the user
+  never returns to the screen that would show the restored fields. Root cause not yet
+  investigated — candidates are `MainActivity`'s `setContent`/`savedInstanceState` handling, or
+  `rememberNavigationState`'s `SavedStateConfiguration` not actually being persisted into the
+  Activity bundle. See `docs/architecture/vm-lifecycle-hardening/IMPLEMENTATION_PLAN.md`.
 - **A stylus first-run tutorial ("Try out your stylus") can pop up over the first tap on
   `Medium_Tablet`** after a fresh-ish boot, identical in shape to the phone AVD's first-run-tutorial
   gotcha elsewhere in this skill — it eats the tap with no error. Screenshot before trusting a tap

--- a/docs/architecture/offline-support.md
+++ b/docs/architecture/offline-support.md
@@ -117,6 +117,17 @@ CreateCommentBar(..., isOffline = isOffline)
 - Consider showing toast/snackbar if user tries to drag while offline
 
 **WorkItem RemoteMediator (Complex)**
+
+**Live-confirmed 2026-08-29** (vm-lifecycle-hardening checklist step 5, see that initiative's
+`IMPLEMENTATION_PLAN.md` finding 9): this gap is not just theoretical. On `Medium_Phone_API_36.1`,
+killing the process, going offline, and relaunching the Issues list screen (Nav3 correctly restores
+the screen, but with a fresh `IssuesViewModel`/`Pager`) replaced the entire previously-loaded issues
+list with a full-screen "Connection error" — `IssuesRepositoryImpl.getIssuesPaging()` builds a plain
+`Pager`/`IssuesPagingSource` straight from `WorkItemApi`, bypassing `WorkItemRepositoryImpl`'s
+cache-first `getWorkItems()` entirely, so none of Phase 3's caching applies to list screens. Same
+structural gap likely affects Epics, Kanban, and ScrumBacklog (same `getXxxPaging()` shape), not
+individually confirmed live.
+
 The WorkItem paging sources have complex server-side filters:
 
 - Assignees, created by, watchers

--- a/docs/architecture/performance-hardening/CHECKLIST-DONE.md
+++ b/docs/architecture/performance-hardening/CHECKLIST-DONE.md
@@ -36,3 +36,38 @@ regression checks..." section:
 workflow is a new decision for gregory to make (a real CI change, and (b) still needs an end-to-end
 seeding prototype before it's committable) — not something this step's "investigate" scope commits
 to starting.
+
+## Step 2: Add APK size delta check to PRs — ✅ done 2026-08-30
+
+Implemented finding (a) from step 1: a new `apk-size-check` job in `.github/workflows/build.yml`,
+parallel to the existing `build` job. Design decision made with gregory first (baseline-APK source
+has a real CI-cost tradeoff): rebuild `dev`'s merge-base commit in the same job rather than fetching
+a `dev`-push-triggered artifact — self-contained, no new push-triggered workflow step, no
+cross-workflow artifact dependency, at the cost of one extra full `assembleFdroidDebug` per PR.
+
+Job does: checkout PR head → `assembleFdroidDebug` → save `head.apk` → `git fetch --depth=1` +
+`checkout` the PR's base sha (`github.event.pull_request.base.sha`) → `assembleFdroidDebug` again →
+save `base.apk` → `usefulness/diffuse-action@v1` (confirmed compatible with this project's AGP
+9.3.1/V2-signed output in step 1) diffs the two → `peter-evans/find-comment@v4` +
+`peter-evans/create-or-update-comment@v5` post/update a single tagged PR comment (`<!-- apk-size-diff
+-->` marker) with `diffuse-action`'s `diff-gh-comment` output, so repeated pushes update one comment
+instead of spamming new ones each time.
+
+Matches this project's existing debug-build signing setup (`TAIGA_ALIAS_D`/`TAIGA_KEY_PASS_D`/
+`TAIGA_STORE_PASS_D`/`ENCODED_STRING_D` env vars, `taigamobilenova_debug.jks` restore) — no
+gplay/`google-services.json` needed since the check only builds the fdroid flavor. Third-party
+action versions pinned to major-version tags (`@v1`/`@v4`/`@v5`), matching this workflow file's
+existing style (`actions/checkout@v7`, etc.) rather than pinning to commit SHAs.
+
+**Verify:** `.github/workflows/build.yml` validated with `actionlint` (via
+`docker run --rm -v "$(pwd)":/repo -w /repo rhysd/actionlint:latest .github/workflows/build.yml`) —
+zero new findings; the only shellcheck notices are pre-existing (`SC2086`, unquoted var in an
+`echo | base64 -d` step already present in the untouched `build` job, and reused here for
+consistency). Not yet verified by an actual PR run — the job's real behavior (Gradle build succeeds
+twice, `diffuse-action` output shape matches what's assumed, the PR comment renders as expected)
+will only be confirmed once this branch's PR runs the workflow for real.
+
+**Next:** step 3 (macrobenchmark CI) is unstarted — see CHECKLIST.md. It is not gated in the
+"needs gregory's decision" sense, but it's substantially larger (real emulator work, an unverified
+`run-as` assumption, an undecided trend-detection design) than step 2 was, so it's being left as its
+own step rather than folded into this one.

--- a/docs/architecture/performance-hardening/CHECKLIST-DONE.md
+++ b/docs/architecture/performance-hardening/CHECKLIST-DONE.md
@@ -1,0 +1,38 @@
+# Performance Hardening — Done Steps
+
+Archive of ticked steps from [CHECKLIST.md](CHECKLIST.md), kept for precedent when a later step
+cites one by number. Not a place to look for open work.
+
+## Step 1: Investigate CI regression checks for APK size and Perfetto/Macrobenchmark trace metrics — ✅ done 2026-08-29
+
+Investigation only, per the step's own "not a commitment to add either check" scope — no workflow
+YAML written, no production change. Findings written into IMPLEMENTATION_PLAN.md's "1. CI
+regression checks..." section:
+
+- **(a) APK size delta:** downloaded `diffuse` 0.3.0 and ran it directly against this project's own
+  built APKs (`app-fdroid-debug.apk` vs `app-gplay-debug.apk`) — it parsed AGP 9.3.1's V2-signed
+  output cleanly and produced the expected dex/arsc/manifest size tables, confirming the tool still
+  works here even though its own upstream repo has been quiet since Feb 2024. `usefulness/diffuse-action`
+  is an actively-maintained wrapper Action (pushed 2026-08-25) worth using instead of hand-rolling
+  the CLI invocation; it only emits the diff as an output, so it'd be paired with
+  `peter-evans/create-or-update-comment` to actually post the PR comment. Fork-PR-secrets gap for
+  the release-accurate variant is still open and unsolved — the debug-vs-base-branch delta sidesteps
+  it and is the recommended first cut.
+- **(b) Macrobenchmark trace metrics:** read `core/storage`'s Android auth persistence code
+  end-to-end. Found that `AndroidKeystoreTokenCipher.decrypt()` has a legacy plaintext-fallback path
+  (any stored value without the `"v1:"` prefix passes through undecrypted) — meaning a
+  pre-authenticated session can be seeded onto a fresh CI emulator by writing *unprefixed* plaintext
+  token values into `auth_storage.preferences_pb`, without ever needing to reproduce the
+  per-install AndroidKeyStore key. Not prototyped end-to-end (the file is a protobuf, so it needs
+  the real DataStore APIs to write correctly, and the `benchmark` module's release build type's
+  `run-as`/`adb root` accessibility is still unverified). Also confirmed
+  `reactivecircus/android-emulator-runner` supports KVM-backed acceleration on GitHub-hosted
+  `ubuntu-latest` runners in principle, not yet tried against this repo. Recommendation stands as
+  written: scheduled/nightly, not per-PR, given emulator cost.
+
+**Verify:** N/A — investigation step, no code changed; findings are the deliverable.
+
+**Next:** queue is empty. Whether to turn either sub-finding into an actual `build.yml`/scheduled
+workflow is a new decision for gregory to make (a real CI change, and (b) still needs an end-to-end
+seeding prototype before it's committable) — not something this step's "investigate" scope commits
+to starting.

--- a/docs/architecture/performance-hardening/CHECKLIST.md
+++ b/docs/architecture/performance-hardening/CHECKLIST.md
@@ -1,11 +1,32 @@
 # Performance Hardening — Checklist
 
-**Progress:** 1/1 done. All checklist steps complete — see CHECKLIST-DONE.md. This file now only
-holds the findings assessed and declined below.
+**Progress:** 2/3 done. Step 3 (macrobenchmark CI) not started — see its entry below.
 
 See [IMPLEMENTATION_PLAN.md](IMPLEMENTATION_PLAN.md) for the source article, the codebase evidence
-behind the finding, and the findings that were assessed and declined. See
-[CHECKLIST-DONE.md](CHECKLIST-DONE.md) for the ticked step.
+behind each finding, and the findings that were assessed and declined. See
+[CHECKLIST-DONE.md](CHECKLIST-DONE.md) for ticked steps.
+
+## Step 3: Prototype macrobenchmark/Perfetto trend-tracking CI end-to-end
+
+Source: step 1's finding (b) — see IMPLEMENTATION_PLAN.md's "(b) Perfetto / Macrobenchmark trace
+metrics on a schedule". Step 2 (this phase's other half, APK size delta on PRs) is done; this is
+the harder, still-undecided half of the same original ask.
+
+Three sub-questions step 1 sketched but did not resolve, in the order they'd need tackling:
+1. Prototype the session-seeding workaround end-to-end on a real emulator (write unprefixed
+   plaintext token/refresh-token values into `auth_storage.preferences_pb` via the real
+   `PreferenceDataStoreFactory`/`edit{}` APIs, confirm `AuthStorageImpl.isLoggedIn`/`getToken()`
+   accept them) — including checking whether the `benchmark` module's `nonMinifiedRelease` build
+   type is `run-as`/`adb root`-accessible, which step 1 flagged as unverified.
+2. Confirm `reactivecircus/android-emulator-runner` actually boots KVM-accelerated on this repo's
+   GitHub-hosted runners (sketched as "viable in principle," not tried here).
+3. Decide a concrete threshold/trend-detection rule for the tracked metric JSON (step 1 explicitly
+   left this undecided) and where the historical series lives (workflow artifact vs. a committed
+   append-only log).
+
+**Verify:** an end-to-end emulator run producing a real `*-benchmarkData.json` from a seeded,
+logged-in session on CI infra (or on a local emulator standing in for it), plus a working
+nightly/manual-dispatch workflow if the prototype holds up.
 
 Findings assessed and declined — see IMPLEMENTATION_PLAN.md for detail, no further action:
 - R8/ProGuard minification + resource shrinking on release builds — already enabled

--- a/docs/architecture/performance-hardening/CHECKLIST.md
+++ b/docs/architecture/performance-hardening/CHECKLIST.md
@@ -1,0 +1,45 @@
+# Performance Hardening — Checklist
+
+**Progress:** 0/1 done. **Current step:** none active — step 1 is not started.
+
+See [IMPLEMENTATION_PLAN.md](IMPLEMENTATION_PLAN.md) for the source article, the codebase evidence
+behind the finding, and the findings that were assessed and declined.
+
+1. Investigate: CI regression checks for APK size and Perfetto/Macrobenchmark trace metrics
+   - Not gated — this is an investigation step, not a commitment to add either check.
+   - Claim to check: an "Android Performance Tuning" newsletter article's size/perf checklist,
+     refined by gregory into a concrete ask — can APK size and startup-trace metrics be tracked
+     automatically per PR (or on a schedule) to catch degradation over time, rather than only via
+     the manual `docs/perf/profiling.md` capture process run ad hoc?
+   - Two distinct sub-checks, deliberately separated because their feasibility differs a lot — see
+     IMPLEMENTATION_PLAN.md's "CI regression checks" section for the full reasoning:
+     - **(a) APK size delta on PRs.** Likely cheap: `build.yml` already assembles fdroid/gplay
+       debug APKs on every PR; a debug-vs-base-branch size diff is a viable first cut. A
+       release-accurate check would reuse the already-enabled R8/shrink-resources release build
+       type, but needs the release signing secrets `build.yml` declares but doesn't currently
+       restore to a file — and fork-originated PRs won't have repo secrets under `pull_request`
+       triggers regardless, so any release-accurate path needs a same-repo-PR fallback story.
+     - **(b) Perfetto/Macrobenchmark trace metrics on a schedule.** Likely too heavy/flaky for
+       every PR: needs a real emulator, and this app's login-required flow (no anonymous path)
+       means a fresh CI emulator can't reach the `:benchmark` module's existing `coldStart()`
+       journey without either scripting a real login or seeding a pre-authenticated session onto
+       the emulator — neither investigated yet. Refined recommendation is a scheduled/nightly job
+       tracking `androidx.benchmark`'s own structured JSON output over time, not a per-PR gate.
+   - Not started — no prototype workflow written, no session-seeding mechanism investigated, no
+     confirmation that `diffuse` (or an equivalent tool) still fits current AGP output.
+
+Findings assessed and declined — see IMPLEMENTATION_PLAN.md for detail, no further action:
+- R8/ProGuard minification + resource shrinking on release builds — already enabled
+  (`AndroidApplicationConventionPlugin.kt:63-64`).
+- Dynamic Feature Modules (Play Feature Delivery) — Android-only mechanism, doesn't fit this
+  project's KMP `feature/*` module structure shared across Android/iOS/Desktop.
+- Overdraw / deep XML layout hierarchies, `ConstraintLayout` — not applicable, this project is
+  100% Jetpack Compose (CLAUDE.md), the article targets the legacy View system.
+- Manual listener/callback cleanup in `onStop`/`onDestroy`, `CameraX`/`MediaPlayer` release — no
+  matching usage in this codebase (`CameraX`, `MediaPlayer`, `androidx.camera` all grep to zero
+  hits); Compose's `DisposableEffect` is the idiomatic equivalent where needed.
+- Offload heavy work off the main thread via coroutines — already the architecture-wide norm
+  (Koin + coroutines), not a gap this article surfaces.
+- Batch network operations to avoid radio wake-ups — overlaps with
+  `docs/architecture/vm-lifecycle-hardening/`'s finding 9 (redundant `init`-time re-fetches);
+  doesn't add anything beyond that already-queued investigation.

--- a/docs/architecture/performance-hardening/CHECKLIST.md
+++ b/docs/architecture/performance-hardening/CHECKLIST.md
@@ -1,32 +1,11 @@
 # Performance Hardening — Checklist
 
-**Progress:** 0/1 done. **Current step:** none active — step 1 is not started.
+**Progress:** 1/1 done. All checklist steps complete — see CHECKLIST-DONE.md. This file now only
+holds the findings assessed and declined below.
 
 See [IMPLEMENTATION_PLAN.md](IMPLEMENTATION_PLAN.md) for the source article, the codebase evidence
-behind the finding, and the findings that were assessed and declined.
-
-1. Investigate: CI regression checks for APK size and Perfetto/Macrobenchmark trace metrics
-   - Not gated — this is an investigation step, not a commitment to add either check.
-   - Claim to check: an "Android Performance Tuning" newsletter article's size/perf checklist,
-     refined by gregory into a concrete ask — can APK size and startup-trace metrics be tracked
-     automatically per PR (or on a schedule) to catch degradation over time, rather than only via
-     the manual `docs/perf/profiling.md` capture process run ad hoc?
-   - Two distinct sub-checks, deliberately separated because their feasibility differs a lot — see
-     IMPLEMENTATION_PLAN.md's "CI regression checks" section for the full reasoning:
-     - **(a) APK size delta on PRs.** Likely cheap: `build.yml` already assembles fdroid/gplay
-       debug APKs on every PR; a debug-vs-base-branch size diff is a viable first cut. A
-       release-accurate check would reuse the already-enabled R8/shrink-resources release build
-       type, but needs the release signing secrets `build.yml` declares but doesn't currently
-       restore to a file — and fork-originated PRs won't have repo secrets under `pull_request`
-       triggers regardless, so any release-accurate path needs a same-repo-PR fallback story.
-     - **(b) Perfetto/Macrobenchmark trace metrics on a schedule.** Likely too heavy/flaky for
-       every PR: needs a real emulator, and this app's login-required flow (no anonymous path)
-       means a fresh CI emulator can't reach the `:benchmark` module's existing `coldStart()`
-       journey without either scripting a real login or seeding a pre-authenticated session onto
-       the emulator — neither investigated yet. Refined recommendation is a scheduled/nightly job
-       tracking `androidx.benchmark`'s own structured JSON output over time, not a per-PR gate.
-   - Not started — no prototype workflow written, no session-seeding mechanism investigated, no
-     confirmation that `diffuse` (or an equivalent tool) still fits current AGP output.
+behind the finding, and the findings that were assessed and declined. See
+[CHECKLIST-DONE.md](CHECKLIST-DONE.md) for the ticked step.
 
 Findings assessed and declined — see IMPLEMENTATION_PLAN.md for detail, no further action:
 - R8/ProGuard minification + resource shrinking on release builds — already enabled

--- a/docs/architecture/performance-hardening/IMPLEMENTATION_PLAN.md
+++ b/docs/architecture/performance-hardening/IMPLEMENTATION_PLAN.md
@@ -62,14 +62,25 @@ size — `build.yml` just asserts the assemble succeeds.
   most for a fast per-PR signal — someone added a large dependency, asset, or accidentally
   unshrunk resource.
 
-**Tooling:** JakeWharton's `diffuse` (CLI + a `diffuse-action` GitHub Action) is the standard
-existing tool for "compare two APK/AAB builds, post a markdown PR comment with size + dex-count +
-resource deltas" — worth checking it still supports whatever this project's current AGP version
-produces before hand-rolling a `du`-based size comparison script.
+**Tooling — confirmed working (2026-08-29).** Downloaded `diffuse` 0.3.0 (JakeWharton/diffuse's
+release binary — the core CLI's last release is Feb 2024, effectively unmaintained upstream but
+stable) and ran it directly against this project's own build output:
+`diffuse diff androidApp/build/outputs/apk/fdroid/debug/app-fdroid-debug.apk
+androidApp/build/outputs/apk/gplay/debug/app-gplay-debug.apk`. It parsed both APKs (AGP 9.3.1
+output, V2 signature scheme) without error and produced the expected dex/arsc/manifest/resource
+size-delta tables plus a per-file diff — confirms the core tool is compatible with this project's
+current AGP version, the open question the checklist step flagged.
 
-**Not started.** No prototype workflow, no confirmation `diffuse` (or an alternative) actually
-works against this project's build output. Treat the fork-PR-secrets gap above as a real open
-question, not a solved edge case, before committing to the release-accurate design.
+For the GitHub Action wrapper: JakeWharton never published one himself. `usefulness/diffuse-action`
+is the actively-maintained community wrapper (pushed 2026-08-25, not archived) — it takes
+`old-file-path`/`new-file-path` and an optional `lib-version` override (defaults to latest
+`diffuse` release), and only exposes the diff as an action *output*; it does not post a PR comment
+itself, so it'd be paired with `peter-evans/create-or-update-comment` (or similar) to actually
+comment the delta on the PR, matching the "post a markdown PR comment" shape from the original ask.
+
+**Still not started:** no prototype `build.yml` job. The fork-PR-secrets gap above is still a real
+open question, not a solved edge case, before committing to the release-accurate design — the
+debug-vs-base-branch delta doesn't need it and is the recommended first cut.
 
 #### (b) Perfetto / Macrobenchmark trace metrics on a schedule
 
@@ -91,15 +102,41 @@ a dependency on but has only used for Baseline Profile generation so far.
 
 - **Login is mandatory, no anonymous path** (`docs/perf/profiling.md`'s own note). A macrobenchmark
   run on a fresh CI emulator starts logged out, but `coldStart()`'s current journey assumes a
-  session already exists and lands on "Select Project." Two options, neither investigated yet:
+  session already exists and lands on "Select Project." Two options:
   (i) extend the journey to script a real login every run — slow, and couples CI to a live Taiga
   instance being reachable from the runner; (ii) seed a pre-authenticated session file onto the
-  emulator's data directory before the benchmark starts — faster and more deterministic, but needs
-  investigating what `core/storage`'s auth persistence actually looks like on disk (DataStore file
-  format/location) before it can be faked reliably.
+  emulator's data directory before the benchmark starts.
+  **Option (ii) investigated (2026-08-29) — more feasible than it looked, with a caveat.** The
+  Android token store (`core/storage/src/androidMain/.../AndroidKeystoreTokenCipher.kt`) encrypts
+  `token`/`refresh_token` with an AES/GCM key generated inside `AndroidKeyStore` — not something a
+  CI script can precompute or transplant onto a fresh emulator. But `AuthStorageImpl`
+  (`core/storage/src/commonMain/.../AuthStorage.kt:23-28`) decrypts via `tokenCipher.decrypt(...)`,
+  and `AndroidKeystoreTokenCipher.decrypt()` has a deliberate legacy fallback: **any stored value
+  that doesn't start with the `"v1:"` ciphertext prefix is passed through unchanged** (it exists to
+  migrate values written before the cipher existed). So a value written *without* that prefix is
+  read back as plaintext with no decryption attempted — the AndroidKeyStore key is never in the
+  loop. That means seeding doesn't require touching the Keystore at all: write plain (unprefixed)
+  token/refresh-token strings into the underlying store and `AuthStorageImpl.isLoggedIn` /
+  `getToken()` will accept them as-is.
+  The store itself is Preferences DataStore, file at
+  `context.preferencesDataStoreFile("auth_storage")` →
+  `/data/data/<applicationId>/files/datastore/auth_storage.preferences_pb`
+  (`StorageModule.android.kt:67-77`, constant in `StorageModule.kt:15`) — a binary protobuf, not a
+  flat key=value file, so it can't be hand-edited byte-for-byte. The safe way to produce a valid
+  one is to call the real `PreferenceDataStoreFactory`/`edit{}` APIs (e.g. from a tiny
+  instrumentation or `adb shell run-as`-scoped setup step run once against a debuggable build)
+  rather than crafting protobuf bytes by hand, then let the emulator boot the real app against that
+  seeded file. **Not yet prototyped end-to-end** — this is confirmed from reading the cipher/store
+  code, not from an actual emulator run — and it still needs the target build variant to be
+  debuggable enough for `run-as` (or `adb root`) to reach app-private storage, which the
+  `benchmark` module's `nonMinifiedRelease` build type may not be by default; that's the next thing
+  to check if this path is picked up.
 - **Emulator cost and flakiness.** Unlike the size check, this needs a real emulator
   (e.g. `reactivecircus/android-emulator-runner`, KVM-backed) — multi-minute boot + install + run
-  per invocation, not a fit for blocking every PR. `docs/perf/profiling.md` also documents real
+  per invocation, not a fit for blocking every PR. GitHub-hosted `ubuntu-latest` runners do support
+  KVM-backed hardware acceleration for this action, gated behind an extra step that adds the
+  runner's user to the KVM udev group before the emulator boots — confirmed viable in principle
+  (not yet tried against this repo's runners). `docs/perf/profiling.md` also documents real
   software-renderer artifacts on the AVD (`swiftshader_indirect` histogram-overflow buckets,
   `Buffer Stuffing` jank-type noise) that a naive single-run CI gate would need to account for or
   it will false-positive on renderer noise, not real regressions.
@@ -111,10 +148,10 @@ a single noisy run. Every-PR gating was the "maybe" gregory floated when raising
 emulator cost and the login blocker are why this refinement downgrades it to scheduled rather than
 per-PR.
 
-**Not started.** This needs its own smaller investigation (what does session seeding actually look
-like, is `reactivecircus/android-emulator-runner` viable on this repo's GitHub-hosted runners,
-what's a sane threshold/trend-detection rule) before it's a committable step rather than a design
-sketch.
+**Still not implemented.** The session-seeding mechanism and the emulator-runner path are now
+sketched (above) rather than unknowns, but neither has been prototyped end-to-end, and a sane
+threshold/trend-detection rule for the tracked JSON is still undecided — this remains a design, not
+a committable step.
 
 ## Candidate for agentic-grappim (project-agnostic, not TaigaMobileNova-specific)
 

--- a/docs/architecture/performance-hardening/IMPLEMENTATION_PLAN.md
+++ b/docs/architecture/performance-hardening/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,126 @@
+# Performance Hardening — Implementation Plan
+
+## Background
+
+Gregory forwarded "Android Performance Tuning: The Art of Making Your App Run on a Potato" (Alan
+Bebido, Medium, Jul 29 2026) — a generic four-bottleneck performance listicle (APK size, RAM,
+UI jank, battery/thermal). Distinct from the "Android Lead" newsletter series behind
+`docs/architecture/vm-lifecycle-hardening/` (different author, different topic — this one is
+performance tuning, not ViewModel lifecycle/error handling), so it gets its own plan doc per
+CLAUDE.md's Multi-Session Work convention rather than being folded into that differently-scoped
+one. The article's individual claims were checked against this codebase rather than taken at face
+value, same process as the other newsletter reviews.
+
+Most of the article's specific advice is either already satisfied or doesn't map onto this
+project's architecture (KMP + Compose Multiplatform, not single-module Android Views) — see the
+declined list in CHECKLIST.md. The one genuinely new, actionable idea came from gregory refining
+the article's "quick summary checklist" into a concrete ask: track APK size and startup
+performance automatically over time (CI, ideally every PR) instead of only via the manual capture
+process `docs/perf/profiling.md` already documents.
+
+## Findings
+
+### 1. CI regression checks for APK size and Perfetto/Macrobenchmark trace metrics (actionable — checklist step 1, investigate first)
+
+Source: the article's "Shrinking the Weight" and "Quick Summary Checklist" sections, refined by
+gregory (2026-08-29): "add the checks for apk size, perfetto traces (if applicable) maybe on every
+PR or something like that, ... see the degradation."
+
+This is really two different checks with very different feasibility, worth treating separately
+rather than as one bundled "perf CI" idea.
+
+#### (a) APK size delta on PRs
+
+**What already exists to build on:** `.github/workflows/build.yml` already runs
+`./gradlew :androidApp:assembleFdroidDebug` and `:androidApp:assembleGplayDebug -PgplayBuild` on
+every PR into `dev` (the `build` job). Nothing currently measures or compares the resulting APK
+size — `build.yml` just asserts the assemble succeeds.
+
+**Debug vs. release accuracy tradeoff:**
+
+- The article itself warns against judging size from a debug build (extra symbol tables,
+  uncompressed code, no shrinking). This project's release build type already has both
+  `isMinifyEnabled = true` and `isShrinkResources = true`
+  (`build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt:63-64`), so a
+  release build is the size that actually ships.
+- But building a signed release APK needs the release keystore. `build.yml`'s `build` job already
+  *declares* `TAIGA_PATH_R` / `TAIGA_KEY_PASS_R` / `TAIGA_STORE_PASS_R` / `TAIGA_ALIAS_R` /
+  `ENCODED_STRING_R` in its `env:` block (lines 26-30) but never restores them to a
+  `taigamobilenova_keystore_release.jks` file the way `release.yml:40` does for the release
+  workflow — only the debug keystore gets restored in `build.yml` today. So release-accurate
+  size measurement needs that restore step added, not just a new gradle task.
+- Even with that fixed, **fork-originated PRs don't get repository secrets** under a plain
+  `pull_request` trigger (only `pull_request_target` gets them, and that trigger has its own
+  well-known security caveats for running untrusted code) — so a release-accurate size check would
+  only work for same-repo-branch PRs, and any design needs an explicit fallback (skip the check, or
+  fall back to the debug-vs-debug delta) for fork PRs rather than silently failing or leaking
+  secrets.
+- **A debug-vs-base-branch delta is the cheap first cut**: build fdroid debug for both the PR head
+  and the PR's merge-base against `dev` (or diff against a stored baseline size from `dev`'s last
+  successful build), compare `app-fdroid-debug.apk` sizes, comment the delta on the PR. Doesn't
+  reflect the real shipped (R8-shrunk) size, but still catches the class of regression that matters
+  most for a fast per-PR signal — someone added a large dependency, asset, or accidentally
+  unshrunk resource.
+
+**Tooling:** JakeWharton's `diffuse` (CLI + a `diffuse-action` GitHub Action) is the standard
+existing tool for "compare two APK/AAB builds, post a markdown PR comment with size + dex-count +
+resource deltas" — worth checking it still supports whatever this project's current AGP version
+produces before hand-rolling a `du`-based size comparison script.
+
+**Not started.** No prototype workflow, no confirmation `diffuse` (or an alternative) actually
+works against this project's build output. Treat the fork-PR-secrets gap above as a real open
+question, not a solved edge case, before committing to the release-accurate design.
+
+#### (b) Perfetto / Macrobenchmark trace metrics on a schedule
+
+**What already exists to build on:** `benchmark/src/main/kotlin/com/grappim/taigamobile/benchmark/BaselineProfileGenerator.kt`
+already has one macrobenchmark journey (`coldStart()`, targeting `com.grappim.taigamobile.fdroid`,
+documented in `docs/perf/profiling.md`), but it's run manually/on-demand for Baseline Profile
+generation today — nothing in `.github/workflows/` touches `:benchmark` at all.
+
+**Why this is a better fit than the manual `docs/perf/profiling.md` process, in principle:**
+AndroidX Macrobenchmark (the library `:benchmark` already depends on) is built for exactly this —
+a `MacrobenchmarkRule` with `StartupTimingMetric`/`FrameTimingMetric` captures a Perfetto trace
+under the hood automatically and emits a structured `*-benchmarkData.json` result per run, without
+needing the by-hand `adb shell perfetto` capture + Python `trace_processor` analysis
+`docs/perf/profiling.md` documents. That JSON is the natural artifact to diff run-over-run for a
+regression signal — this isn't a from-scratch design, it's wiring up infra the project already has
+a dependency on but has only used for Baseline Profile generation so far.
+
+**Real blockers, not glossed over:**
+
+- **Login is mandatory, no anonymous path** (`docs/perf/profiling.md`'s own note). A macrobenchmark
+  run on a fresh CI emulator starts logged out, but `coldStart()`'s current journey assumes a
+  session already exists and lands on "Select Project." Two options, neither investigated yet:
+  (i) extend the journey to script a real login every run — slow, and couples CI to a live Taiga
+  instance being reachable from the runner; (ii) seed a pre-authenticated session file onto the
+  emulator's data directory before the benchmark starts — faster and more deterministic, but needs
+  investigating what `core/storage`'s auth persistence actually looks like on disk (DataStore file
+  format/location) before it can be faked reliably.
+- **Emulator cost and flakiness.** Unlike the size check, this needs a real emulator
+  (e.g. `reactivecircus/android-emulator-runner`, KVM-backed) — multi-minute boot + install + run
+  per invocation, not a fit for blocking every PR. `docs/perf/profiling.md` also documents real
+  software-renderer artifacts on the AVD (`swiftshader_indirect` histogram-overflow buckets,
+  `Buffer Stuffing` jank-type noise) that a naive single-run CI gate would need to account for or
+  it will false-positive on renderer noise, not real regressions.
+
+**Refined recommendation:** don't gate every PR on this. Run it on a schedule (nightly, or
+manual-dispatch) against `dev`, track the metric JSON over time (workflow artifact, or a small
+append-only log committed somewhere), and alert only on a sustained trend or threshold breach, not
+a single noisy run. Every-PR gating was the "maybe" gregory floated when raising the idea; the
+emulator cost and the login blocker are why this refinement downgrades it to scheduled rather than
+per-PR.
+
+**Not started.** This needs its own smaller investigation (what does session seeding actually look
+like, is `reactivecircus/android-emulator-runner` viable on this repo's GitHub-hosted runners,
+what's a sane threshold/trend-detection rule) before it's a committable step rather than a design
+sketch.
+
+## Candidate for agentic-grappim (project-agnostic, not TaigaMobileNova-specific)
+
+Not yet written up — flagging for later: "AndroidX Macrobenchmark's structured JSON output is a
+better CI regression-tracking primitive than a hand-rolled Perfetto capture + trace_processor
+script" is general Android knowledge, not specific to this codebase's architecture. Worth a shared
+note in `agentic-grappim` next time it's touched, once this project's own investigation above
+actually confirms the approach works end-to-end (don't write up a pattern that hasn't been proven
+here yet).

--- a/docs/architecture/performance-hardening/IMPLEMENTATION_PLAN.md
+++ b/docs/architecture/performance-hardening/IMPLEMENTATION_PLAN.md
@@ -153,11 +153,11 @@ sketched (above) rather than unknowns, but neither has been prototyped end-to-en
 threshold/trend-detection rule for the tracked JSON is still undecided — this remains a design, not
 a committable step.
 
-## Candidate for agentic-grappim (project-agnostic, not TaigaMobileNova-specific)
+## Written up in agentic-grappim (project-agnostic, not TaigaMobileNova-specific)
 
-Not yet written up — flagging for later: "AndroidX Macrobenchmark's structured JSON output is a
-better CI regression-tracking primitive than a hand-rolled Perfetto capture + trace_processor
-script" is general Android knowledge, not specific to this codebase's architecture. Worth a shared
-note in `agentic-grappim` next time it's touched, once this project's own investigation above
-actually confirms the approach works end-to-end (don't write up a pattern that hasn't been proven
-here yet).
+**Done 2026-08-30**, though explicitly marked unconfirmed there per its own caveat below: "AndroidX
+Macrobenchmark's structured JSON output is a better CI regression-tracking primitive than a
+hand-rolled Perfetto capture + trace_processor script" is now in the shared `mobile-patterns` skill
+(`agentic-grappim/skills/mobile-patterns/SKILL.md`), flagged as *not yet proven end-to-end* — this
+project's own step 3 (macrobenchmark CI, still queued) is what would confirm or correct it. Update
+that skill entry once step 3 actually lands, rather than leaving it as a permanent caveat.

--- a/docs/architecture/vm-lifecycle-hardening/CHECKLIST-DONE.md
+++ b/docs/architecture/vm-lifecycle-hardening/CHECKLIST-DONE.md
@@ -82,3 +82,29 @@ reasoning in IMPLEMENTATION_PLAN.md's "Constructor-injected initial state (OTOS)
 
 **Next:** steps 4-7 are all ungated and available; step 4 (watch/unwatch race fix) is the only one
 with a concrete implementation already scoped rather than being an investigation.
+
+## Step 4: Gate the watch/unwatch button on `areWatchersLoading` — ✅ done 2026-08-29
+
+Applied exactly the fix the checklist scoped: `WatchersWidget.kt`'s watch/unwatch
+`TaigaTextButtonWidget` now passes `isOffline = isOffline || watchersState.areWatchersLoading`
+instead of bare `isOffline`. One-line change, reuses the existing disabled-button visual (same
+pattern the widget already uses for `isOffline`) — no new prop, no state-shape change.
+
+Did not additionally pursue the "worth weighing" optimistic-update alternative noted in the
+checklist entry — the step scoped only the disable-button fix, and the note explicitly flagged
+that path as undecided/not scoped.
+
+**Verify:** `./gradlew jvmTest` — full suite green. `./gradlew :feature:workitem:ui:ktlintCheck` —
+green. Live GUI verification on the desktop app (`:composeApp:run`) was attempted but
+inconclusive: `xdotool` clicks against the app window registered only intermittently (see
+`docs/frictions.md`'s 2026-08-29 entry) — same coordinates sometimes toggled the UI, sometimes did
+nothing, with no error, across ~10 attempts on three different buttons including plain
+back-navigation. Not caused by this change (the pre-existing "Watch" button was equally
+unclickable). Verified the fix by code read instead: `areWatchersLoading` is set true for the
+duration of `handleAddMeToWatchers`/`handleRemoveMeFromWatchers` in
+`WorkItemWatchersDelegateImpl.kt` and `TaigaTextButtonWidget`'s `isOffline` param already disables
+the button and suppresses its `onClick` (same mechanism the widget's other `isOffline`-gated
+buttons rely on) — confirmed by reading `TaigaTextButtonWidget`'s implementation.
+
+**Next:** steps 5-7 are all ungated investigation steps and available in any order; none is more
+scoped than the others. Step 5 (redundant init-time re-fetches) is next in checklist order.

--- a/docs/architecture/vm-lifecycle-hardening/CHECKLIST-DONE.md
+++ b/docs/architecture/vm-lifecycle-hardening/CHECKLIST-DONE.md
@@ -108,3 +108,61 @@ buttons rely on) — confirmed by reading `TaigaTextButtonWidget`'s implementati
 
 **Next:** steps 5-7 are all ungated investigation steps and available in any order; none is more
 scoped than the others. Step 5 (redundant init-time re-fetches) is next in checklist order.
+
+## Step 5: Investigate redundant `init`-time re-fetches — ✅ done 2026-08-29
+
+Static-grep pass corrected the checklist's own candidate list: `getPermissions()` is called
+unconditionally in 8 ViewModels, not the 5 originally listed, and `KanbanViewModel` — named as a
+candidate — doesn't call it at all (that came from a different, conflated grep). Traced
+`getPermissions()` to a **local Room read** (`projectDao.getProjectById`), not network — the
+article's "transient network blip" risk doesn't apply to it, so it's not actionable.
+`loadFiltersData()`/`getFiltersData()` (Epics, Issues, Kanban, ScrumBacklog list screens) **is** a
+genuine unconditional network re-fetch matching the article's claim.
+
+Live-verified on `IssuesViewModel`/`IssuesScreen` (`Medium_Phone_API_36.1`, fdroid debug): process
+death + airplane mode + relaunch reproduced the predicted failure, but the dominant visible effect
+was bigger than expected — the entire issues list vanished behind a full-screen "Connection error",
+not just a filters warning badge. Traced that to a separate mechanism, which turned out to already be
+a known, deferred gap: `docs/architecture/offline-support.md`'s Phase 4 already flags "WorkItem
+[Paging] deferred" — `IssuesRepositoryImpl.getIssuesPaging()` bypasses the cache-first
+`WorkItemRepositoryImpl.getWorkItems()` entirely, so no RemoteMediator/Room backs list screens' Paging
+sources. Added a dated confirmation note to that doc's "WorkItem RemoteMediator (Complex)" section
+rather than opening a new, duplicate tracking item. Full evidence and reasoning in
+IMPLEMENTATION_PLAN.md finding 9.
+
+**No fix applied — this was investigate-only per its scope.** `getPermissions()` — declined, doesn't
+match the source article's risk model (it's a local Room read, not network). `loadFiltersData()` —
+confirmed real but secondary; a fix there wouldn't have prevented the actual UX regression observed,
+which traces to the pre-existing, already-tracked Paging-cache gap instead.
+
+**Verify:** live reproduction on device/emulator as described above (no code changed, so no
+`jvmTest`/`ktlintCheck` run).
+
+**Next:** steps 6 and 7 are ungated investigation steps and available in either order.
+
+## Step 6: Investigate whether the watch/unwatch race generalizes — ✅ done 2026-08-29
+
+Yes — the same shape (an `areXxxLoading` flag tracked in state and shown as a spinner, but not used
+to gate the button/icon that fires the write) recurs in three more delegates:
+`WorkItemWatchersDelegateImpl.handleRemoveWatcher` (the per-watcher remove icon — step 4's fix only
+covered the toggle button, not this, even though it's the same `_watchersState`),
+`WorkItemSingleAssigneeDelegateImpl`/`WorkItemMultipleAssigneesDelegateImpl` (Assign-to-me/Unassign
+toggle + per-assignee remove), and `WorkItemTagsDelegateImpl.handleTagRemove` (per-tag remove chip).
+The three remove-actions are worse than a UI glitch — each computes its patch payload from a stale
+`_xxxState.value` snapshot taken at call time, so two rapid removes can silently undo each other's
+result. `WorkItemSprintDelegateImpl`/`WorkItemDueDateDelegateImpl` checked and set aside — both are
+dialog-gated single-confirm actions, not a reachable button pair. Full evidence in
+IMPLEMENTATION_PLAN.md finding 10.
+
+**No fix applied — investigate-only per its scope**, despite the fix pattern being obvious (identical
+to step 4's, at three more sites) — added as new ungated checklist step 8 rather than applied inline,
+consistent with how step 5 stayed investigate-only. No live reproduction attempted for these three;
+the concurrency proof is direct from the code (shared mutable state, no ordering guard, ungated
+trigger, stale-snapshot read) and didn't need a click sequence to establish, unlike step 5's Paging
+finding which only became visible by actually running the app.
+
+**Verify:** code-read only, no production code changed this step (`jvmTest`/`ktlintCheck` not run —
+nothing to verify).
+
+**Next:** step 7 is ungated and available. Step 8 (new) is ungated too — same fix pattern as step 4,
+just at three more call sites.

--- a/docs/architecture/vm-lifecycle-hardening/CHECKLIST-DONE.md
+++ b/docs/architecture/vm-lifecycle-hardening/CHECKLIST-DONE.md
@@ -24,3 +24,34 @@ convention (for `testScheduler`) already used elsewhere (e.g. `UserStoryDetailsV
 
 **Next:** step 2 is gated — do not start without asking gregory to decide process-death UI-state
 restoration scope. Step 3 (OTOS investigation) is not gated and can be picked up instead.
+
+## Step 2: Process-death back-stack restoration gap — ✅ done 2026-08-29
+
+Root cause was neither of the two candidates the checklist named (Nav3's own restoration
+mechanism was never broken). `MainNavHost`'s top-level `LaunchedEffect(initialNavState.isReady)`
+was unconditionally calling `navigator.navigateToDashboardAsTopDestination()` — a
+`resetTo(DashboardNavDestination)` that wipes every nav section — on every cold app start where
+the user is logged in with a project selected, including a process-death relaunch after Nav3 had
+already restored a deeper back stack (e.g. `Dashboard` → `CreateTask`). That reset stomped the
+correctly-restored stack down to bare `Dashboard` every time.
+
+Fix (`composeApp/src/commonMain/kotlin/com/grappim/taigamobile/main/MainNavHost.kt`): gated the
+reset on `navigationState.currentKey == LoginNavDestination` (the seed value — true only when
+nothing has diverged the stack yet). Verifying the fix on the emulator surfaced a second bug in
+the same code path: with the reset skipped, the restored screen rendered correctly underneath but
+the splash screen never dismissed, because `ScreenReadySignalController.signalReady()` was only
+called from the `Login`/`ProjectSelector`/`Dashboard` `entry<>` blocks (see that class's doc
+comment) — a restored deeper screen never composes any of those three. Fixed by calling
+`screenReadySignal.signalReady()` directly in the gated `LaunchedEffect`'s `else` branch. Full
+mechanism, both bugs, and the emulator verification steps are in IMPLEMENTATION_PLAN.md's
+"Process-death UI-state restoration" section.
+
+**Verify:** `./gradlew jvmTest` and `./gradlew ktlintCheck` both green. Emulator-verified on
+`Medium_Phone_API_36.1` (fdroid debug): filled the Create Task form, backgrounded, `am kill`
+(confirmed dead via `ps`), relaunched with `am start -n` (`sz=1`, genuine task resume) — landed
+directly back on Create Task with both fields intact, no stuck splash. Re-verified the untouched
+fresh-start path (force-stop, relaunch with nothing to restore) still lands cleanly on Dashboard.
+
+**Next:** step 3 (OTOS investigation) is not gated and is ready to start. `RestorableState` can now
+also be rolled out to further form screens if wanted — that rollout was parked pending this fix and
+is not itself scoped as a checklist step yet.

--- a/docs/architecture/vm-lifecycle-hardening/CHECKLIST-DONE.md
+++ b/docs/architecture/vm-lifecycle-hardening/CHECKLIST-DONE.md
@@ -55,3 +55,30 @@ fresh-start path (force-stop, relaunch with nothing to restore) still lands clea
 **Next:** step 3 (OTOS investigation) is not gated and is ready to start. `RestorableState` can now
 also be rolled out to further form screens if wanted — that rollout was parked pending this fix and
 is not itself scoped as a checklist step yet.
+
+## Step 3: Investigate constructor-injected `initialState` (OTOS) — ✅ done 2026-08-29
+
+Grepped every `*ViewModelTest.kt` for the longest single-test chain of `onXChange`/`setX` calls to
+find the concrete candidate the step asked for; `ProjectDetailsViewModelTest`'s `onSaveClick -
+success` test was the worst offender (6 chained setters). Prototyped removing that chain two ways,
+without any production-code change:
+
+- `ProjectDetailsViewModelTest` (repo-loaded form): `save()` reads `_state.value`, which `init`
+  populates straight from the fake's `getProjectDetailsResult`. Setting the fake's result to the
+  *target* state directly reaches it in one step — the fake's return value already is the
+  constructor-time seam OTOS wants a new `initialState` param for.
+- `CreateTaskViewModelTest` (route/`SavedStateHandle`-driven form, no repo load in `init`):
+  pre-seeding the constructor's `SavedStateHandle` with the target title/description reaches the
+  same state in one step, reusing the `restorableState.restore(...)` path step 2 already built.
+
+**Declined the convention.** No VM examined lacked an existing collaborator-based seam (fake repo
+result, `SavedStateHandle` initial map, route nav-args) sufficient to reach any target state in one
+step — a dedicated `initialState` constructor param would duplicate that path, not remove setup
+cost. Both simplified tests are kept as the actual fix for the two worst chains found. Full
+reasoning in IMPLEMENTATION_PLAN.md's "Constructor-injected initial state (OTOS)" section.
+
+**Verify:** `./gradlew jvmTest` — full suite green. `./gradlew :feature:settings:ui:ktlintCommonTestSourceSetCheck
+:composeApp:ktlintCommonTestSourceSetCheck` — green.
+
+**Next:** steps 4-7 are all ungated and available; step 4 (watch/unwatch race fix) is the only one
+with a concrete implementation already scoped rather than being an investigation.

--- a/docs/architecture/vm-lifecycle-hardening/CHECKLIST-DONE.md
+++ b/docs/architecture/vm-lifecycle-hardening/CHECKLIST-DONE.md
@@ -1,0 +1,26 @@
+# ViewModel Lifecycle & Error-Handling Hardening — Done Steps
+
+Archive of ticked steps from [CHECKLIST.md](CHECKLIST.md), kept for precedent when a later step
+cites one by number. Not a place to look for open work.
+
+## Step 1: Add a `CoroutineExceptionHandler` to `provideApplicationScope` — ✅ done 2026-08-29
+
+Added a top-level `applicationScopeExceptionHandler` (`CoroutineExceptionHandler`) in
+`core/async-kmp/src/commonMain/kotlin/com/grappim/taigamobile/core/asynckmp/KmpCorotuinesModule.kt`
+that logs via `logcat(LogPriority.ERROR, throwable = throwable) { "Unhandled exception on
+ApplicationScope" }`, and added it to `provideApplicationScope`'s `CoroutineScope(...)` context
+alongside the existing `SupervisorJob() + defaultDispatcher`. No change to the function's
+signature or call sites (`AuthStateManager.logout()`, `TaigaApp.onCreate()`).
+
+Added `core/async-kmp/src/commonTest/kotlin/com/grappim/taigamobile/core/asynckmp/KmpCoroutinesModuleTest.kt`
+(new `commonTest` source set for this module — none existed before) — installs a recording
+`TaigaLogger` fake, launches a coroutine on the produced scope that throws, and asserts the
+throwable was logged at `ERROR` with the original throwable instance, and that the exception did
+not propagate out of `launch`/fail the test. Follows the file's `@file:OptIn(ExperimentalCoroutinesApi::class)`
+convention (for `testScheduler`) already used elsewhere (e.g. `UserStoryDetailsViewModelTest.kt`).
+
+**Verify:** `./gradlew jvmTest` — full suite green, including the new test. `./gradlew
+:core:async-kmp:ktlintCheck` — green.
+
+**Next:** step 2 is gated — do not start without asking gregory to decide process-death UI-state
+restoration scope. Step 3 (OTOS investigation) is not gated and can be picked up instead.

--- a/docs/architecture/vm-lifecycle-hardening/CHECKLIST-DONE.md
+++ b/docs/architecture/vm-lifecycle-hardening/CHECKLIST-DONE.md
@@ -190,3 +190,31 @@ since nothing here is being missed; it's already how the code is structured.
 
 **Next:** step 8 (extend step 4's fix to three more delegates) is the only step left — ungated, ready
 to start.
+
+## Step 8: Extend step 4's button-gating fix to the delegates step 6 found — ✅ done 2026-08-29
+
+Applied the same one-line pattern as step 4 (`isOffline = isOffline || <state>.areXxxLoading`) at the
+three sites step 6 found:
+- `WatchersWidget.kt`'s per-watcher remove icon (`TeamUserWithActionWidget` call) — now
+  `isOffline || watchersState.areWatchersLoading`.
+- `AssignedToWidget.kt`'s per-assignee remove icon and the Assign-to-me/Unassign toggle — both now
+  `isOffline || isAssigneesLoading` (shared by `SingleAssignedToWidget`/`MultipleAssignedToWidget`,
+  so both delegates are covered by the one widget change).
+- `WorkItemTagsWidget.kt`'s per-tag remove click (`TagItemWidget`) — now
+  `isOffline || tagsState.areTagsLoading`.
+
+Did not touch "Add assignee"/"Add watcher"/"Edit tags" — those open a separate screen/dialog rather
+than directly writing to the racing state, so they're not part of the confirmed race.
+
+**Verify:** `./gradlew jvmTest` — full suite green. `./gradlew :feature:workitem:ui:ktlintCheck` —
+green. GUI-verified on `Medium_Phone_API_36.1` (fdroid debug, adb-driven — this session's `xdotool`
+flakiness was specific to the desktop build, not the emulator): installed the rebuilt APK, opened
+Issue #82's detail screen, confirmed Tags/Assigned-to/Watchers all render correctly and their
+buttons stay enabled in the idle (not-loading) state — no regression. Did not attempt to force and
+screenshot the actual in-flight-disabled state (would need airplane-mode timing per the
+emulator-testing skill); the fix is mechanically identical to step 4's, which was accepted on code
++ test evidence alone.
+
+**Next:** queue is empty — all 8 checklist steps are done. The initiative's remaining open item is
+IMPLEMENTATION_PLAN.md finding 9's Paging-cache gap, which was deliberately routed to
+`docs/architecture/offline-support.md` instead of tracked here (see step 5's note above).

--- a/docs/architecture/vm-lifecycle-hardening/CHECKLIST-DONE.md
+++ b/docs/architecture/vm-lifecycle-hardening/CHECKLIST-DONE.md
@@ -166,3 +166,27 @@ nothing to verify).
 
 **Next:** step 7 is ungated and available. Step 8 (new) is ungated too — same fix pattern as step 4,
 just at three more call sites.
+
+## Step 7: Investigate UiState-leak and derived-property convention — ✅ done 2026-08-29
+
+Static-grep pass over all 37 `*State.kt` files under `feature/*/ui` found no violation of either
+sub-claim. No `isXxx`-shaped field encodes a derived rendering decision anywhere — the only
+`*Visible`-shaped fields are dialog-open flags (raw user-toggled state, not a leak), and no list
+screen stores an `isEmpty`-style field at all. The article's `get()`-property convention already
+exists in the one place it's earned: `CustomFieldItemState.isModified`, used at 5+ call sites
+(delegate, three widget spots, a test) — genuinely avoiding duplicated `originalValue != currentValue`
+logic, consistent with CLAUDE.md's own "no abstraction for single-use code" rule. Everywhere else,
+the same de-duplication goal is met a different way this project already relies on more heavily: a
+shared widget (`WikiListContentWidget`) or shared extension functions
+(`utils/ui/.../PagingUtils.kt`'s `hasError()`/`isNotLoading()`/`hasCompletedLoad()`) computing the
+render-branch decision once, called from every screen that needs it, rather than a `get()` per State
+class. Full evidence in IMPLEMENTATION_PLAN.md finding 11.
+
+**No action — the convention is already followed in substance**, just via composition (shared
+widgets/extensions) more often than via `get()` properties. Not written up as a new CLAUDE.md rule
+since nothing here is being missed; it's already how the code is structured.
+
+**Verify:** static analysis only, no code changed (no `jvmTest`/`ktlintCheck` to run).
+
+**Next:** step 8 (extend step 4's fix to three more delegates) is the only step left — ungated, ready
+to start.

--- a/docs/architecture/vm-lifecycle-hardening/CHECKLIST.md
+++ b/docs/architecture/vm-lifecycle-hardening/CHECKLIST.md
@@ -1,0 +1,133 @@
+# ViewModel Lifecycle & Error-Handling Hardening — Checklist
+
+**Progress:** 0/7 done. **Current step:** none active — step 1 is ready to start.
+
+See [IMPLEMENTATION_PLAN.md](IMPLEMENTATION_PLAN.md) for the source articles, the codebase
+evidence behind each finding, and the findings that were assessed and declined.
+
+1. Add a `CoroutineExceptionHandler` to `provideApplicationScope`
+   - Confirmed gap: `core/async-kmp/src/commonMain/kotlin/com/grappim/taigamobile/core/asynckmp/KmpCorotuinesModule.kt`'s
+     `provideApplicationScope` builds `CoroutineScope(SupervisorJob() + defaultDispatcher)` with no
+     exception handler. Two production call sites (`AuthStateManager.logout()`, `TaigaApp.onCreate()`'s
+     cache-clean call and crash-reporting-toggle flow) launch on it unguarded — any exception there
+     is silently swallowed by `SupervisorJob` semantics, violating CLAUDE.md's Error Handling rule.
+   - Fix: add a `CoroutineExceptionHandler` to `provideApplicationScope` in `KmpCoroutinesModule`
+     that logs via `logcat(LogPriority.ERROR, throwable = e) { "Unhandled exception on ApplicationScope" }`.
+   - Verify: `./gradlew jvmTest`; add a test proving an exception thrown inside a coroutine launched
+     on the scope is logged, not silently dropped or propagated as a crash.
+
+2. ⛔ **Gated — do not start without asking.** Decide scope for process-death UI-state restoration
+   - Confirmed gap: `SavedStateHandle` is unused anywhere in production code — every ViewModel's
+     `MutableStateFlow`-held state resets to its hardcoded default on process death (no
+     `UiStateMachine`/Parcelable-state wrapper exists anywhere in the codebase).
+   - Needs a decision from gregory before any code: which screens actually warrant this (multi-step
+     forms / entry flows where losing user-entered data costs something, vs. simple list/detail
+     screens that just re-fetch and lose nothing a user would notice), and whether to build a shared
+     `UiStateMachine`-style wrapper project-wide up front or add it ad hoc per screen as needed.
+   - Not started — see IMPLEMENTATION_PLAN.md's "Process-death UI-state restoration" section for the
+     tradeoffs to weigh once picked up.
+
+3. Investigate: constructor-injected `initialState` for multi-field form/edit ViewModels (OTOS)
+   - Not gated — this is an investigation step, not a commitment to change the convention project-wide.
+   - Claim to check: "Why your ViewModel is untestable" argues hardcoded initial state forces tests
+     to reach a target state through a chain of setter calls (its own coined "OTOS — one test, one
+     state" rule), and that constructor-injecting `initialState` (with a default) fixes it. Assessed
+     2026-08-29: doesn't help this project's common load-and-display VMs (already one-line fake
+     setup), but could genuinely help multi-field form/edit screens (create task, edit sprint, etc.)
+     where tests currently chain several `viewModel.onXChanged(...)` calls to reach one target state.
+   - Scope the investigation to one concrete form VM (pick one with the most setter-chaining in its
+     existing tests — grep `grep -c "onX\|onSet\|onChange" **/*ViewModelTest.kt`-style to find a
+     candidate) and prototype `initialState` injection there before deciding whether to generalize.
+     Some VMs (e.g. `SettingsUserScreenViewModel`) derive part of their default state from injected
+     repos/storage at construction time, so this isn't a uniform one-line change everywhere — note
+     which shape a candidate VM has before committing to the pattern.
+   - Also worth reading alongside the source article: "Why your ViewModel is untestable" itself
+     cites "The Importance of One Test One Assertion (OTOA) in Unit Testing" (DaniG, Treatwell
+     Product Engineering Blog, 2025-03-02). It refines OTOA more precisely than the newsletter's
+     shorthand: the rule is one test asserts one *behaviour*, not literally one assertion call — a
+     single `assertThat(...).extracting(...)` checking several unrelated fields still violates it
+     even though it's syntactically one statement. Worth keeping that distinction when evaluating
+     this project's own tests against OTOA.
+   - Not started — see IMPLEMENTATION_PLAN.md's "Constructor-injected initial state (OTOS)" section.
+
+4. Gate the watch/unwatch button on `areWatchersLoading` (last-write-wins race)
+   - Confirmed gap: `WorkItemWatchersDelegateImpl.handleAddMeToWatchers`/`handleRemoveMeFromWatchers`
+     each run as their own independent `viewModelScope.launch`, doing several sequential network
+     calls before writing `isWatchedByMe` into `_watchersState`. The watch/unwatch button in
+     `WatchersWidget.kt` is never disabled while `areWatchersLoading` is true (only gated on
+     `isOffline`), so a user can tap watch then unwatch before the first request returns — whichever
+     response lands second wins, regardless of which action the user took last. Affects all four
+     screens sharing this delegate/widget: Task, UserStory, Epic, Issue detail.
+   - Fix: pass `isOffline = isOffline || watchersState.areWatchersLoading` to the watch/unwatch
+     `TaigaTextButtonWidget` call in `WatchersWidget.kt` (feature/workitem/ui). Reuses the existing
+     disabled-button visual; no new prop, no MVI rearchitecture.
+   - Verify: `./gradlew jvmTest`; confirm on the emulator/desktop app per CLAUDE.md's Verification
+     rule (this is a UI-visible change) that the button visibly disables while a watch/unwatch
+     request is in flight.
+   - Worth weighing before starting (not decided): going optimistic instead of/in addition to
+     disabling the button — same pattern `KanbanViewModel.moveStory()` already uses for drag-and-drop
+     (update state immediately, revert + show error on failure). See IMPLEMENTATION_PLAN.md finding
+     8's "Secondary source" note (*What Are Optimistic Updates?*) for the tradeoff. Not scoped yet.
+
+5. Investigate: redundant `init`-time re-fetches of already-known/rarely-changing data
+   - Not gated — this is an investigation step, not a commitment to change anything project-wide.
+   - Claim to check: "How to load ViewModel's data without using 'init'" (its Issue 3, "Customer that
+     never returns") argues that unconditionally re-running an `init`-time load on every VM
+     reconstruction — even for data that already loaded successfully and rarely changes — creates
+     avoidable failure windows: a transient network blip on the re-fetch turns a screen that *was*
+     fine into an error, costing a conversion for no reason tied to the actual data. Distinct from
+     finding 3 above (that one is about test flakiness from concurrent loads) and from checklist step
+     2 (that one is about losing *user-entered* input on process death) — this is about needlessly
+     re-risking read-only/rarely-changing data on any VM recreation, not just process death.
+   - Candidates already surfaced by finding 3's grep: `EpicsViewModel`, `IssuesViewModel`,
+     `KanbanViewModel`, `ScrumBacklogViewModel`, `EditSprintViewModel` all unconditionally call
+     `getPermissions()` from `init` — permissions rarely change mid-session, so every re-entry into
+     these screens re-risks a network call that already succeeded once.
+   - Approach agreed with gregory (2026-08-29): finding candidates is a static-grep pass (does the
+     `init`-time load fetch data that's already known or unlikely to change, e.g. permissions, nav-arg
+     data, already-cached repository reads?) — not something that needs live reproduction to
+     enumerate. Only reproduce live (emulator, airplane-mode toggle around a re-navigation) on the one
+     or two candidates actually picked, to confirm the UX regression is real, not as a blanket sweep.
+   - Not started.
+
+6. Investigate: does the watch/unwatch last-write-wins race (step 4) generalize elsewhere
+   - Not gated — this is an investigation step, not a commitment to fix anything beyond step 4.
+   - Claim to check: step 4's race (two independent `viewModelScope.launch` blocks writing to
+     overlapping state with no ordering/cancellation guard, reachable by a user firing both before
+     the first resolves) was found while investigating watchers specifically — the codebase was
+     never swept for other ViewModels/delegates with the same shape.
+   - Approach: static grep first — state classes/delegates with more than one independent `launch`
+     site writing into the same `MutableStateFlow`, shortlisted by whether the UI actually exposes
+     two overlapping triggers a user could reach (button pair, double-tappable toggle), the way
+     `WatchersWidget` does. Only reproduce live on candidates that survive the shortlist, not as a
+     blanket sweep.
+   - Not started — see IMPLEMENTATION_PLAN.md's "Does the watch/unwatch race generalize?" section.
+
+7. Investigate: UiState-leak and derived-property convention
+   - Not gated — this is an investigation step, not a commitment to change anything project-wide.
+   - Claim to check: "Sealed State vs. Data State" (finding 6 already validated its headline
+     data-class-over-sealed conclusion) also argues (a) a State field is a "UI-decision leak" if it
+     encodes a rendering decision rather than raw data, regardless of sealed vs. data class, and
+     (b) UI-only derived booleans should be `get()` properties on the State class, not stored fields
+     or logic duplicated inline in Composables/mappers.
+   - Approach: static grep over `*State.kt` classes for rendering-decision-shaped field names
+     (`isEmpty`, `showX`, `xVisible`) that are stored fields rather than `get()` properties, and for
+     existing `get()` properties to see whether the convention is already partially followed. Only
+     dig into live behavior/tests for whatever candidates the grep turns up.
+   - Not started — see IMPLEMENTATION_PLAN.md's "UiState-leak and derived-property convention"
+     section.
+
+Findings assessed and declined — see IMPLEMENTATION_PLAN.md for detail, no further action:
+- Concurrent independent loads fired from `init` (the "Startup-Intent" article's flaky-test claim)
+  — confirmed 8 ViewModels do this, but the current test convention (final `.state.value` snapshot
+  assertions + `MainDispatcherRule`'s unconfined dispatcher) already sidesteps the flakiness the
+  article describes.
+- `AppInfoProvider.isDebug()` runtime facade (the "debug code in release builds" article) — matches
+  the flagged anti-pattern, but the article's fix (Android build-type source sets) doesn't
+  generalize across this project's iOS/JVM targets.
+- State design (data class, not sealed) — already matches the article's recommended convention.
+- The Startup-Intent pattern, the Startup Task multibinding pattern, "MVP vs MVVM vs MVI", and the
+  custom FIFO/`UiStateMachine`/`MviViewModel` machinery from "Why your MVI can't handle two Intents
+  at once" — not applicable, they presuppose an MVI pipeline or Hilt multibinding this project
+  doesn't use. That last article's underlying race-condition claim is not MVI-specific though — it
+  produced its own actionable finding, step 4 above.

--- a/docs/architecture/vm-lifecycle-hardening/CHECKLIST.md
+++ b/docs/architecture/vm-lifecycle-hardening/CHECKLIST.md
@@ -1,45 +1,12 @@
 # ViewModel Lifecycle & Error-Handling Hardening — Checklist
 
-**Progress:** 4/7 done. **Current step:** none active — steps 5-7 are all ungated investigation
-steps and available in any order; step 5 is next in checklist order.
+**Progress:** 6/7 done. **Current step:** none active — step 7 is ungated and available. Step 8 is
+new (found while doing step 6) and ungated — it's the same one-line fix pattern step 4 already used,
+just at three more call sites.
 
 See [IMPLEMENTATION_PLAN.md](IMPLEMENTATION_PLAN.md) for the source articles, the codebase
 evidence behind each finding, and the findings that were assessed and declined. See
 [CHECKLIST-DONE.md](CHECKLIST-DONE.md) for ticked steps.
-
-5. Investigate: redundant `init`-time re-fetches of already-known/rarely-changing data
-   - Not gated — this is an investigation step, not a commitment to change anything project-wide.
-   - Claim to check: "How to load ViewModel's data without using 'init'" (its Issue 3, "Customer that
-     never returns") argues that unconditionally re-running an `init`-time load on every VM
-     reconstruction — even for data that already loaded successfully and rarely changes — creates
-     avoidable failure windows: a transient network blip on the re-fetch turns a screen that *was*
-     fine into an error, costing a conversion for no reason tied to the actual data. Distinct from
-     finding 3 above (that one is about test flakiness from concurrent loads) and from checklist step
-     2 (that one is about losing *user-entered* input on process death) — this is about needlessly
-     re-risking read-only/rarely-changing data on any VM recreation, not just process death.
-   - Candidates already surfaced by finding 3's grep: `EpicsViewModel`, `IssuesViewModel`,
-     `KanbanViewModel`, `ScrumBacklogViewModel`, `EditSprintViewModel` all unconditionally call
-     `getPermissions()` from `init` — permissions rarely change mid-session, so every re-entry into
-     these screens re-risks a network call that already succeeded once.
-   - Approach agreed with gregory (2026-08-29): finding candidates is a static-grep pass (does the
-     `init`-time load fetch data that's already known or unlikely to change, e.g. permissions, nav-arg
-     data, already-cached repository reads?) — not something that needs live reproduction to
-     enumerate. Only reproduce live (emulator, airplane-mode toggle around a re-navigation) on the one
-     or two candidates actually picked, to confirm the UX regression is real, not as a blanket sweep.
-   - Not started.
-
-6. Investigate: does the watch/unwatch last-write-wins race (step 4) generalize elsewhere
-   - Not gated — this is an investigation step, not a commitment to fix anything beyond step 4.
-   - Claim to check: step 4's race (two independent `viewModelScope.launch` blocks writing to
-     overlapping state with no ordering/cancellation guard, reachable by a user firing both before
-     the first resolves) was found while investigating watchers specifically — the codebase was
-     never swept for other ViewModels/delegates with the same shape.
-   - Approach: static grep first — state classes/delegates with more than one independent `launch`
-     site writing into the same `MutableStateFlow`, shortlisted by whether the UI actually exposes
-     two overlapping triggers a user could reach (button pair, double-tappable toggle), the way
-     `WatchersWidget` does. Only reproduce live on candidates that survive the shortlist, not as a
-     blanket sweep.
-   - Not started — see IMPLEMENTATION_PLAN.md's "Does the watch/unwatch race generalize?" section.
 
 7. Investigate: UiState-leak and derived-property convention
    - Not gated — this is an investigation step, not a commitment to change anything project-wide.
@@ -54,6 +21,30 @@ evidence behind each finding, and the findings that were assessed and declined. 
      dig into live behavior/tests for whatever candidates the grep turns up.
    - Not started — see IMPLEMENTATION_PLAN.md's "UiState-leak and derived-property convention"
      section.
+
+8. Extend step 4's button-gating fix to the delegates step 6 found doing the same thing
+   - Not gated — same one-line fix pattern step 4 already used (`isOffline = isOffline ||
+     state.areXxxLoading`) validated by gregory, just applied to three more sites. Not a design
+     question.
+   - Confirmed real in IMPLEMENTATION_PLAN.md finding 10 (step 6's investigation): every case below
+     already has an `areXxxLoading`/`isXxxLoading` flag in state, already rendered as a spinner, but
+     the button(s)/icon(s) that fire the write are gated only by `isOffline`:
+     - `WorkItemWatchersDelegateImpl.handleRemoveWatcher` — the per-watcher remove icon in
+       `WatchersWidget` (via `TeamUserWithActionWidget`, `TeamUserWidget.kt:99-107`) — step 4 fixed
+       only the watch/unwatch toggle button, not this. Same `_watchersState` step 4 touched.
+     - `WorkItemSingleAssigneeDelegateImpl` / `WorkItemMultipleAssigneesDelegateImpl` — the
+       Assign-to-me/Unassign toggle (`AssignedToWidget.kt:160-171`) and the per-assignee remove icon
+       (same `TeamUserWithActionWidget`).
+     - `WorkItemTagsDelegateImpl.handleTagRemove` — each tag chip's remove click (`TagItemWidget`,
+       used from `WorkItemTagsWidget.kt`).
+   - Fix: same shape as step 4 at each site — `isOffline = isOffline || <state>.areXxxLoading` on the
+     relevant button/icon's `enabled`/`isOffline` param. Four screens share `WatchersWidget`
+     (Task/UserStory/Epic/Issue details); `AssignedToWidget` and `WorkItemTagsWidget` are likely
+     shared the same way — check call sites before assuming the count.
+   - Verify: `./gradlew jvmTest` and `ktlintCheck`; per CLAUDE.md's Verification rule this is
+     UI-visible — attempt a live check on device/emulator, but this session's `xdotool` clicks against
+     the desktop build were unreliable (`docs/frictions.md`, 2026-08-29) enough that code-read +
+     `jvmTest` may be the practical fallback again.
 
 Findings assessed and declined — see IMPLEMENTATION_PLAN.md for detail, no further action:
 - Concurrent independent loads fired from `init` (the "Startup-Intent" article's flaky-test claim)

--- a/docs/architecture/vm-lifecycle-hardening/CHECKLIST.md
+++ b/docs/architecture/vm-lifecycle-hardening/CHECKLIST.md
@@ -1,35 +1,11 @@
 # ViewModel Lifecycle & Error-Handling Hardening — Checklist
 
-**Progress:** 7/7 done, plus a new ungated step 8 found while doing step 6. **Current step:** step 8
-is the only one left — ungated, same one-line fix pattern step 4 already used.
+**Progress:** 8/8 done. All checklist steps complete — see CHECKLIST-DONE.md. This file now only
+holds the findings assessed and declined below.
 
 See [IMPLEMENTATION_PLAN.md](IMPLEMENTATION_PLAN.md) for the source articles, the codebase
 evidence behind each finding, and the findings that were assessed and declined. See
 [CHECKLIST-DONE.md](CHECKLIST-DONE.md) for ticked steps.
-
-8. Extend step 4's button-gating fix to the delegates step 6 found doing the same thing
-   - Not gated — same one-line fix pattern step 4 already used (`isOffline = isOffline ||
-     state.areXxxLoading`) validated by gregory, just applied to three more sites. Not a design
-     question.
-   - Confirmed real in IMPLEMENTATION_PLAN.md finding 10 (step 6's investigation): every case below
-     already has an `areXxxLoading`/`isXxxLoading` flag in state, already rendered as a spinner, but
-     the button(s)/icon(s) that fire the write are gated only by `isOffline`:
-     - `WorkItemWatchersDelegateImpl.handleRemoveWatcher` — the per-watcher remove icon in
-       `WatchersWidget` (via `TeamUserWithActionWidget`, `TeamUserWidget.kt:99-107`) — step 4 fixed
-       only the watch/unwatch toggle button, not this. Same `_watchersState` step 4 touched.
-     - `WorkItemSingleAssigneeDelegateImpl` / `WorkItemMultipleAssigneesDelegateImpl` — the
-       Assign-to-me/Unassign toggle (`AssignedToWidget.kt:160-171`) and the per-assignee remove icon
-       (same `TeamUserWithActionWidget`).
-     - `WorkItemTagsDelegateImpl.handleTagRemove` — each tag chip's remove click (`TagItemWidget`,
-       used from `WorkItemTagsWidget.kt`).
-   - Fix: same shape as step 4 at each site — `isOffline = isOffline || <state>.areXxxLoading` on the
-     relevant button/icon's `enabled`/`isOffline` param. Four screens share `WatchersWidget`
-     (Task/UserStory/Epic/Issue details); `AssignedToWidget` and `WorkItemTagsWidget` are likely
-     shared the same way — check call sites before assuming the count.
-   - Verify: `./gradlew jvmTest` and `ktlintCheck`; per CLAUDE.md's Verification rule this is
-     UI-visible — attempt a live check on device/emulator, but this session's `xdotool` clicks against
-     the desktop build were unreliable (`docs/frictions.md`, 2026-08-29) enough that code-read +
-     `jvmTest` may be the practical fallback again.
 
 Findings assessed and declined — see IMPLEMENTATION_PLAN.md for detail, no further action:
 - Concurrent independent loads fired from `init` (the "Startup-Intent" article's flaky-test claim)

--- a/docs/architecture/vm-lifecycle-hardening/CHECKLIST.md
+++ b/docs/architecture/vm-lifecycle-hardening/CHECKLIST.md
@@ -1,26 +1,11 @@
 # ViewModel Lifecycle & Error-Handling Hardening — Checklist
 
-**Progress:** 6/7 done. **Current step:** none active — step 7 is ungated and available. Step 8 is
-new (found while doing step 6) and ungated — it's the same one-line fix pattern step 4 already used,
-just at three more call sites.
+**Progress:** 7/7 done, plus a new ungated step 8 found while doing step 6. **Current step:** step 8
+is the only one left — ungated, same one-line fix pattern step 4 already used.
 
 See [IMPLEMENTATION_PLAN.md](IMPLEMENTATION_PLAN.md) for the source articles, the codebase
 evidence behind each finding, and the findings that were assessed and declined. See
 [CHECKLIST-DONE.md](CHECKLIST-DONE.md) for ticked steps.
-
-7. Investigate: UiState-leak and derived-property convention
-   - Not gated — this is an investigation step, not a commitment to change anything project-wide.
-   - Claim to check: "Sealed State vs. Data State" (finding 6 already validated its headline
-     data-class-over-sealed conclusion) also argues (a) a State field is a "UI-decision leak" if it
-     encodes a rendering decision rather than raw data, regardless of sealed vs. data class, and
-     (b) UI-only derived booleans should be `get()` properties on the State class, not stored fields
-     or logic duplicated inline in Composables/mappers.
-   - Approach: static grep over `*State.kt` classes for rendering-decision-shaped field names
-     (`isEmpty`, `showX`, `xVisible`) that are stored fields rather than `get()` properties, and for
-     existing `get()` properties to see whether the convention is already partially followed. Only
-     dig into live behavior/tests for whatever candidates the grep turns up.
-   - Not started — see IMPLEMENTATION_PLAN.md's "UiState-leak and derived-property convention"
-     section.
 
 8. Extend step 4's button-gating fix to the delegates step 6 found doing the same thing
    - Not gated — same one-line fix pattern step 4 already used (`isOffline = isOffline ||

--- a/docs/architecture/vm-lifecycle-hardening/CHECKLIST.md
+++ b/docs/architecture/vm-lifecycle-hardening/CHECKLIST.md
@@ -1,20 +1,10 @@
 # ViewModel Lifecycle & Error-Handling Hardening — Checklist
 
-**Progress:** 0/7 done. **Current step:** none active — step 1 is ready to start.
+**Progress:** 1/7 done. **Current step:** none active — step 2 is gated; step 3 is ready to start.
 
 See [IMPLEMENTATION_PLAN.md](IMPLEMENTATION_PLAN.md) for the source articles, the codebase
-evidence behind each finding, and the findings that were assessed and declined.
-
-1. Add a `CoroutineExceptionHandler` to `provideApplicationScope`
-   - Confirmed gap: `core/async-kmp/src/commonMain/kotlin/com/grappim/taigamobile/core/asynckmp/KmpCorotuinesModule.kt`'s
-     `provideApplicationScope` builds `CoroutineScope(SupervisorJob() + defaultDispatcher)` with no
-     exception handler. Two production call sites (`AuthStateManager.logout()`, `TaigaApp.onCreate()`'s
-     cache-clean call and crash-reporting-toggle flow) launch on it unguarded — any exception there
-     is silently swallowed by `SupervisorJob` semantics, violating CLAUDE.md's Error Handling rule.
-   - Fix: add a `CoroutineExceptionHandler` to `provideApplicationScope` in `KmpCoroutinesModule`
-     that logs via `logcat(LogPriority.ERROR, throwable = e) { "Unhandled exception on ApplicationScope" }`.
-   - Verify: `./gradlew jvmTest`; add a test proving an exception thrown inside a coroutine launched
-     on the scope is logged, not silently dropped or propagated as a crash.
+evidence behind each finding, and the findings that were assessed and declined. See
+[CHECKLIST-DONE.md](CHECKLIST-DONE.md) for ticked steps.
 
 2. ⛔ **Gated — do not start without asking.** Decide scope for process-death UI-state restoration
    - Confirmed gap: `SavedStateHandle` is unused anywhere in production code — every ViewModel's

--- a/docs/architecture/vm-lifecycle-hardening/CHECKLIST.md
+++ b/docs/architecture/vm-lifecycle-hardening/CHECKLIST.md
@@ -1,34 +1,12 @@
 # ViewModel Lifecycle & Error-Handling Hardening — Checklist
 
-**Progress:** 2/7 done. **Current step:** none active — step 3 (OTOS investigation) is ready to
-start next; steps 4-7 are also ungated and available.
+**Progress:** 3/7 done. **Current step:** none active — steps 4-7 are all ungated and available;
+step 4 (watch/unwatch race fix) is the only one with a concrete implementation already scoped
+rather than being an investigation.
 
 See [IMPLEMENTATION_PLAN.md](IMPLEMENTATION_PLAN.md) for the source articles, the codebase
 evidence behind each finding, and the findings that were assessed and declined. See
 [CHECKLIST-DONE.md](CHECKLIST-DONE.md) for ticked steps.
-
-3. Investigate: constructor-injected `initialState` for multi-field form/edit ViewModels (OTOS)
-   - Not gated — this is an investigation step, not a commitment to change the convention project-wide.
-   - Claim to check: "Why your ViewModel is untestable" argues hardcoded initial state forces tests
-     to reach a target state through a chain of setter calls (its own coined "OTOS — one test, one
-     state" rule), and that constructor-injecting `initialState` (with a default) fixes it. Assessed
-     2026-08-29: doesn't help this project's common load-and-display VMs (already one-line fake
-     setup), but could genuinely help multi-field form/edit screens (create task, edit sprint, etc.)
-     where tests currently chain several `viewModel.onXChanged(...)` calls to reach one target state.
-   - Scope the investigation to one concrete form VM (pick one with the most setter-chaining in its
-     existing tests — grep `grep -c "onX\|onSet\|onChange" **/*ViewModelTest.kt`-style to find a
-     candidate) and prototype `initialState` injection there before deciding whether to generalize.
-     Some VMs (e.g. `SettingsUserScreenViewModel`) derive part of their default state from injected
-     repos/storage at construction time, so this isn't a uniform one-line change everywhere — note
-     which shape a candidate VM has before committing to the pattern.
-   - Also worth reading alongside the source article: "Why your ViewModel is untestable" itself
-     cites "The Importance of One Test One Assertion (OTOA) in Unit Testing" (DaniG, Treatwell
-     Product Engineering Blog, 2025-03-02). It refines OTOA more precisely than the newsletter's
-     shorthand: the rule is one test asserts one *behaviour*, not literally one assertion call — a
-     single `assertThat(...).extracting(...)` checking several unrelated fields still violates it
-     even though it's syntactically one statement. Worth keeping that distinction when evaluating
-     this project's own tests against OTOA.
-   - Not started — see IMPLEMENTATION_PLAN.md's "Constructor-injected initial state (OTOS)" section.
 
 4. Gate the watch/unwatch button on `areWatchersLoading` (last-write-wins race)
    - Confirmed gap: `WorkItemWatchersDelegateImpl.handleAddMeToWatchers`/`handleRemoveMeFromWatchers`

--- a/docs/architecture/vm-lifecycle-hardening/CHECKLIST.md
+++ b/docs/architecture/vm-lifecycle-hardening/CHECKLIST.md
@@ -1,24 +1,11 @@
 # ViewModel Lifecycle & Error-Handling Hardening — Checklist
 
-**Progress:** 1/7 done. **Current step:** none active — step 2's back-stack-restoration gap is next
-(ungated, do it before step 3 or any other step); step 3 remains ready to start after that.
+**Progress:** 2/7 done. **Current step:** none active — step 3 (OTOS investigation) is ready to
+start next; steps 4-7 are also ungated and available.
 
 See [IMPLEMENTATION_PLAN.md](IMPLEMENTATION_PLAN.md) for the source articles, the codebase
 evidence behind each finding, and the findings that were assessed and declined. See
 [CHECKLIST-DONE.md](CHECKLIST-DONE.md) for ticked steps.
-
-2. Process-death UI-state restoration — VM-level piece landed, back-stack gap next (own task)
-   - Scope decided 2026-08-29: forms/entry-flow screens only, with a shared reusable helper
-     (`RestorableState` in `utils/ui`) rather than ad hoc per-field code. Piloted on
-     `CreateTaskViewModel` — implementation is correct and tested (see IMPLEMENTATION_PLAN.md).
-   - An emulator check found the Nav3 back stack itself does not survive a real process kill in this
-     app (relaunch lands on Dashboard, not the screen the user was on), which makes the pilot's
-     `SavedStateHandle` restoration currently inert end-to-end — necessary but not sufficient.
-   - **Decided 2026-08-29: investigate and fix the back-stack gap next, as its own task, in a new
-     session, before anything else on this initiative.** Root-cause candidates and full detail are
-     in IMPLEMENTATION_PLAN.md's "Process-death UI-state restoration" section. Do not roll
-     `RestorableState` out to any other screen until this is fixed — there is no provable payoff
-     yet.
 
 3. Investigate: constructor-injected `initialState` for multi-field form/edit ViewModels (OTOS)
    - Not gated — this is an investigation step, not a commitment to change the convention project-wide.

--- a/docs/architecture/vm-lifecycle-hardening/CHECKLIST.md
+++ b/docs/architecture/vm-lifecycle-hardening/CHECKLIST.md
@@ -1,31 +1,11 @@
 # ViewModel Lifecycle & Error-Handling Hardening — Checklist
 
-**Progress:** 3/7 done. **Current step:** none active — steps 4-7 are all ungated and available;
-step 4 (watch/unwatch race fix) is the only one with a concrete implementation already scoped
-rather than being an investigation.
+**Progress:** 4/7 done. **Current step:** none active — steps 5-7 are all ungated investigation
+steps and available in any order; step 5 is next in checklist order.
 
 See [IMPLEMENTATION_PLAN.md](IMPLEMENTATION_PLAN.md) for the source articles, the codebase
 evidence behind each finding, and the findings that were assessed and declined. See
 [CHECKLIST-DONE.md](CHECKLIST-DONE.md) for ticked steps.
-
-4. Gate the watch/unwatch button on `areWatchersLoading` (last-write-wins race)
-   - Confirmed gap: `WorkItemWatchersDelegateImpl.handleAddMeToWatchers`/`handleRemoveMeFromWatchers`
-     each run as their own independent `viewModelScope.launch`, doing several sequential network
-     calls before writing `isWatchedByMe` into `_watchersState`. The watch/unwatch button in
-     `WatchersWidget.kt` is never disabled while `areWatchersLoading` is true (only gated on
-     `isOffline`), so a user can tap watch then unwatch before the first request returns — whichever
-     response lands second wins, regardless of which action the user took last. Affects all four
-     screens sharing this delegate/widget: Task, UserStory, Epic, Issue detail.
-   - Fix: pass `isOffline = isOffline || watchersState.areWatchersLoading` to the watch/unwatch
-     `TaigaTextButtonWidget` call in `WatchersWidget.kt` (feature/workitem/ui). Reuses the existing
-     disabled-button visual; no new prop, no MVI rearchitecture.
-   - Verify: `./gradlew jvmTest`; confirm on the emulator/desktop app per CLAUDE.md's Verification
-     rule (this is a UI-visible change) that the button visibly disables while a watch/unwatch
-     request is in flight.
-   - Worth weighing before starting (not decided): going optimistic instead of/in addition to
-     disabling the button — same pattern `KanbanViewModel.moveStory()` already uses for drag-and-drop
-     (update state immediately, revert + show error on failure). See IMPLEMENTATION_PLAN.md finding
-     8's "Secondary source" note (*What Are Optimistic Updates?*) for the tradeoff. Not scoped yet.
 
 5. Investigate: redundant `init`-time re-fetches of already-known/rarely-changing data
    - Not gated — this is an investigation step, not a commitment to change anything project-wide.

--- a/docs/architecture/vm-lifecycle-hardening/CHECKLIST.md
+++ b/docs/architecture/vm-lifecycle-hardening/CHECKLIST.md
@@ -1,21 +1,24 @@
 # ViewModel Lifecycle & Error-Handling Hardening — Checklist
 
-**Progress:** 1/7 done. **Current step:** none active — step 2 is gated; step 3 is ready to start.
+**Progress:** 1/7 done. **Current step:** none active — step 2's back-stack-restoration gap is next
+(ungated, do it before step 3 or any other step); step 3 remains ready to start after that.
 
 See [IMPLEMENTATION_PLAN.md](IMPLEMENTATION_PLAN.md) for the source articles, the codebase
 evidence behind each finding, and the findings that were assessed and declined. See
 [CHECKLIST-DONE.md](CHECKLIST-DONE.md) for ticked steps.
 
-2. ⛔ **Gated — do not start without asking.** Decide scope for process-death UI-state restoration
-   - Confirmed gap: `SavedStateHandle` is unused anywhere in production code — every ViewModel's
-     `MutableStateFlow`-held state resets to its hardcoded default on process death (no
-     `UiStateMachine`/Parcelable-state wrapper exists anywhere in the codebase).
-   - Needs a decision from gregory before any code: which screens actually warrant this (multi-step
-     forms / entry flows where losing user-entered data costs something, vs. simple list/detail
-     screens that just re-fetch and lose nothing a user would notice), and whether to build a shared
-     `UiStateMachine`-style wrapper project-wide up front or add it ad hoc per screen as needed.
-   - Not started — see IMPLEMENTATION_PLAN.md's "Process-death UI-state restoration" section for the
-     tradeoffs to weigh once picked up.
+2. Process-death UI-state restoration — VM-level piece landed, back-stack gap next (own task)
+   - Scope decided 2026-08-29: forms/entry-flow screens only, with a shared reusable helper
+     (`RestorableState` in `utils/ui`) rather than ad hoc per-field code. Piloted on
+     `CreateTaskViewModel` — implementation is correct and tested (see IMPLEMENTATION_PLAN.md).
+   - An emulator check found the Nav3 back stack itself does not survive a real process kill in this
+     app (relaunch lands on Dashboard, not the screen the user was on), which makes the pilot's
+     `SavedStateHandle` restoration currently inert end-to-end — necessary but not sufficient.
+   - **Decided 2026-08-29: investigate and fix the back-stack gap next, as its own task, in a new
+     session, before anything else on this initiative.** Root-cause candidates and full detail are
+     in IMPLEMENTATION_PLAN.md's "Process-death UI-state restoration" section. Do not roll
+     `RestorableState` out to any other screen until this is fixed — there is no provable payoff
+     yet.
 
 3. Investigate: constructor-injected `initialState` for multi-field form/edit ViewModels (OTOS)
    - Not gated — this is an investigation step, not a commitment to change the convention project-wide.

--- a/docs/architecture/vm-lifecycle-hardening/IMPLEMENTATION_PLAN.md
+++ b/docs/architecture/vm-lifecycle-hardening/IMPLEMENTATION_PLAN.md
@@ -388,41 +388,77 @@ one-line change; going optimistic is a separate, larger step (still needs the sa
 or a rethink of it, to avoid two optimistic toggles racing the same way) and hasn't been scoped.
 Noting it here as an option to weigh when step 4 is picked up, not committing to it.
 
-### 9. Redundant `init`-time re-fetches of already-known/rarely-changing data (actionable — checklist step 5, investigate first)
+### 9. Redundant `init`-time re-fetches of already-known/rarely-changing data (done — checklist step 5, see CHECKLIST-DONE.md)
 
 Source: *How to load ViewModel's data without using 'init'* (2026-07-19), its Issue 3 ("Customer
 that never returns") — distinct from finding 3 above, which only checked that article's Issue 1
 (test flakiness). Issue 3's argument: unconditionally re-running an `init`-time load on every VM
 reconstruction, even for data that already loaded successfully and rarely changes, creates an
 avoidable failure window — a transient network blip on the re-fetch turns a screen that *was* fine
-into an error, for data that didn't need re-fetching at all. The article frames this as a direct
-revenue-loss argument ("Any error, any additional click, any lost state - it's an additional user
-action, which always leads to revenue loss. → Don't rely on perfect network conditions. Avoid
-requests as much as you can.").
+into an error, for data that didn't need re-fetching at all.
 
 This is a different root cause from checklist step 2 (process-death loses *user-entered* input) —
 Issue 3 is about read-only/rarely-changing data getting needlessly re-risked on *any* VM
 reconstruction, not specifically process death.
 
-Candidates already surfaced by finding 3's grep (same VMs, different reason this time):
-`EpicsViewModel`, `IssuesViewModel`, `KanbanViewModel`, `ScrumBacklogViewModel`,
-`EditSprintViewModel` all unconditionally call `getPermissions()` from `init` — permissions rarely
-change mid-session, so every re-entry into these screens re-risks a network call that already
-succeeded once, for data that's very unlikely to have changed.
+**Static-grep pass (corrects the checklist's own candidate list).** `getPermissions()` is called
+unconditionally from `init`/its `loadData()` in 8 ViewModels, not the 5 originally listed:
+`WikiPagesViewModel`, `WikiBookmarksViewModel`, `ScrumBacklogViewModel`, `ScrumOpenSprintsViewModel`,
+`EditSprintViewModel`, `EpicsViewModel`, `SprintViewModel`, `IssuesViewModel`. `KanbanViewModel` —
+named in the checklist as a candidate — does **not** call `getPermissions()` at all; it was carried
+over from finding 3's *different* grep (2+ independent `init`-time launches, where Kanban's second
+launch is `loadFiltersData()`, not permissions) and the two lists got conflated when step 5 was
+scoped.
 
-Its implementation guideline (`MviConfig`, startup-vs-user Intent naming convention,
-`@Restartable`-annotation filtering, abstract `MviViewModel` base class) is not applicable here —
-same reason as findings 7/8: presupposes the MVI Intent/reducer pipeline this project doesn't have.
+**`getPermissions()` turned out not to match the article's actual concern.** Traced the call:
+`ProjectsRepositoryImpl.getPermissions()` → `getCurrentProjectSimple()` →
+`projectDao.getProjectById(currentProjectId)` — a **local Room read**, not a network call (Room
+data is written by whatever last synced the project, e.g. `fetchAndSaveProjectInfo()` on Dashboard
+load). Issue 3's "transient network blip" risk doesn't apply to it — a local DB read essentially
+can't fail under normal operation. Re-running it on every `init` is a wasted read, not a
+revenue-risking failure window. **Not actionable under this article's argument.**
 
-**Approach agreed with gregory (2026-08-29):** finding candidates is a static-grep pass — does the
-`init`-time load fetch data that's already known or unlikely to change (permissions, nav-arg data,
-an already-cached repository read)? That doesn't need live reproduction to enumerate. Only reproduce
-live (emulator, airplane-mode toggle around a re-navigation) on the one or two candidates actually
-picked, to confirm the UX regression is real — not as a blanket sweep across every VM.
+**`loadFiltersData()` (→ `getFiltersData()`) is the real match.** Called unconditionally from
+`init` in `EpicsViewModel`, `IssuesViewModel`, `KanbanViewModel`, `ScrumBacklogViewModel` — traced to
+`FiltersRepositoryImpl.getFiltersData()` → `filtersApi.getCommonTaskFiltersData(...)`, a genuine Ktor
+network call for a task type's filter options (statuses/tags/priorities/assignees), re-issued on
+every re-entry into these four list screens even though a project's filter options rarely change
+mid-session.
 
-Checklist step 5 scopes this as an investigation, not a commitment to change anything project-wide.
+**Live-verified on `IssuesViewModel`/`IssuesScreen`** (`Medium_Phone_API_36.1`, fdroid debug,
+2026-08-29): loaded the Issues screen online (list + filters both fine) → backgrounded, `am kill`
+(confirmed dead via `pidof`) → `adb shell cmd connectivity airplane-mode enable` → relaunched with
+`am start -n` (`Warning: Activity not started, its current task has been brought to the front`,
+confirming genuine task resume) — Nav3 restored directly to Issues (step 2's fix holding), but with
+a **fresh** `IssuesViewModel`, whose `init` re-ran `getPermissions()` and `loadFiltersData()` against
+no network. Result matched Issue 3's prediction and then some: "Show filters" got a red warning
+badge (`filtersError` set) as expected, but the *dominant* effect was the entire issues list being
+replaced by a full-screen "Connection error" + Retry — hiding the exact same list the user had been
+looking at seconds earlier. Re-enabling airplane mode + tapping Retry (`issues.refresh()` +
+`state.retryLoadFilters()`, `IssuesScreen.kt:157-161`) fully recovered both.
 
-### 10. Does the watch/unwatch race generalize? (actionable — checklist step 6, investigate first)
+**The full-screen wipeout is a separate, bigger mechanism than either scoped candidate — and turns
+out to be an already-tracked, already-deferred gap, not a new one.** `IssuesScreen.kt`'s
+`issues.hasError() && issues.isEmpty()` branch (line 152) is what renders it —
+`IssuesRepositoryImpl.getIssuesPaging()` builds a plain `Pager`/`IssuesPagingSource` straight from
+`WorkItemApi`, bypassing `WorkItemRepositoryImpl`'s cache-first `getWorkItems()` entirely, so none of
+`docs/architecture/offline-support.md`'s Phase 3 caching applies to list screens. That doc already
+names this precisely: Phase 4 is "⚠️ PARTIAL — Sprint RemoteMediator done; WorkItem deferred", and its
+"WorkItem RemoteMediator (Complex)" future-work section already explains why (complex server-side
+filters). This session's contribution is confirming *live* that the deferred gap produces a real,
+visible UX regression (not just a theoretical one) — added as a dated note there rather than a new
+checklist item here, to avoid tracking the same gap in two places. Same structural shape likely
+affects Epics, Kanban, and ScrumBacklog (same `getXxxPaging()` pattern) — not individually confirmed
+live.
+
+**Conclusion:** `getPermissions()` — no action, doesn't match the article's risk model.
+`loadFiltersData()` — confirmed real, but a fix there (e.g. skip re-fetch if already loaded, keep
+last-known filters on failure) wouldn't fix the actual dominant symptom users would hit, since that's
+driven by the pre-existing, already-deferred Paging-cache gap, not the filters call. See
+`docs/architecture/offline-support.md`'s "WorkItem RemoteMediator (Complex)" section for that gap's
+existing tracking — not duplicated as a new checklist step here.
+
+### 10. Does the watch/unwatch race generalize? (done — checklist step 6, see CHECKLIST-DONE.md)
 
 Prompted by gregory re-reading finding 8 (2026-08-29): that finding confirmed one instance of
 "nothing defines update order, any method mutates any field from any coroutine" (the *Why your MVI
@@ -435,15 +471,52 @@ Claim to check: are there other places with two-or-more independent `viewModelSc
 cancellation/versioning/ordering guard, reachable by a user firing both before the first resolves —
 the same last-write-wins shape as watch/unwatch?
 
-Approach (same static-first pattern as findings 3/9): grep for state classes/delegates with more
-than one independent `launch` site writing into the same `MutableStateFlow`/`_xxxState`, shortlist
-candidates by whether the UI actually exposes two overlapping triggers (a button pair, a
-toggle a user can double-tap, two rapid-fire actions on the same field) the way `WatchersWidget`
-does — not every concurrent write is reachable by a real double-action. Only reproduce live on
-whichever candidates survive the shortlist, not as a blanket sweep.
+**Yes — confirmed the same shape in three more delegates, plus a gap step 4 itself left open.**
+Static-grep pass over `feature/workitem/ui/.../delegates/*` for an `areXxxLoading`/`isXxxLoading`
+flag that's tracked in state and shown as a spinner, but not used to gate the button(s) that fire the
+write:
 
-Checklist step 6 scopes this as an investigation, not a commitment to fix anything beyond what step
-4 already covers.
+- **`WorkItemWatchersDelegateImpl.handleRemoveWatcher`** (the per-watcher remove icon in
+  `WatchersWidget`, via the shared `TeamUserWithActionWidget`) writes to the *same* `_watchersState`
+  step 4 already fixed the toggle button for — but the remove icon
+  (`TeamUserWidget.kt:99-107`, `enabled = !isOffline`) was never included in step 4's fix (which was
+  scoped only to "the watch/unwatch button"). Worse than a UI toggle glitch: `handleRemoveWatcher`
+  computes `newWatchers`/`watchersToSave` by filtering `_watchersState.value.watchers` — a **stale
+  snapshot** taken at call time — so two rapid removes (or a remove racing the toggle button) can
+  silently undo each other's result, not just show a wrong loading state.
+- **`WorkItemSingleAssigneeDelegateImpl` / `WorkItemMultipleAssigneesDelegateImpl`** — identical
+  shape to watchers pre-fix: `isAssigneesLoading` is tracked and shown via `DotsLoaderWidget`
+  (`AssignedToWidget.kt:128`), but the Assign-to-me/Unassign toggle
+  (`AssignedToWidget.kt:160-171`, `isOffline = isOffline`) and the per-assignee remove icon (same
+  `TeamUserWithActionWidget` as watchers) are both ungated. `handleRemoveAssignee` (multiple) has the
+  same stale-snapshot problem as `handleRemoveWatcher` above — computes `newAssignees` by filtering
+  `_multipleAssigneesState.value.assignees` at call time.
+- **`WorkItemTagsDelegateImpl.handleTagRemove`** — same shape again: `areTagsLoading` shown as a
+  `CircularProgressIndicator` (`WorkItemTagsWidget.kt:62-67`), but each tag chip's remove click
+  (`TagItemWidget`, gated only by `isOffline`) is not gated by it, and `handleTagRemove` computes
+  `newTags` from a stale `_tagsState.value.tags` snapshot too — reachable any time 2+ tags are shown,
+  which is common.
+
+**Checked and set aside as lower-risk:** `WorkItemSprintDelegateImpl` (edit/create sprint) and
+`WorkItemDueDateDelegateImpl` — both are dialog-gated single-confirm actions, not a pair of
+independently-clickable buttons/icons sitting on the screen at once, so the "user fires both before
+the first resolves" reachability that makes watchers/assignees/tags real doesn't apply the same way.
+Not dug into further, per the shortlist approach.
+
+**Root cause is identical across all four (three new + the original) — the same fix pattern applies.**
+Every case is: an `areXxxLoading`/`isXxxLoading` flag already exists in state and is already rendered
+as a loading spinner, but the actionable button(s)/icon(s) are gated only by `isOffline`, not by that
+loading flag too. Step 4's fix (`isOffline = isOffline || state.areXxxLoading`) is a direct, one-line
+template at each site — no new investigation needed to know *what* the fix looks like, just where to
+apply it. Not applied here (step 6 is investigate-only) — proposed as new checklist step 8.
+
+No live reproduction done for these three (unlike step 4's original, which also wasn't live-verified
+before its fix — see finding 8 — and unlike step 5, where live reproduction was the only way to
+surface the Paging-cache mechanism). The concurrency proof here is direct from the code: shared
+mutable state, no cancellation/ordering guard, a UI trigger not gated by the in-flight flag, and (for
+the three remove-actions) a stale-snapshot read that would produce visibly wrong data — no live click
+sequence needed to establish this is real, and this session's earlier click-flakiness with the
+desktop build (`docs/frictions.md`, 2026-08-29) made another live-repro attempt low-value.
 
 ### 11. UiState-leak and derived-property convention (actionable — checklist step 7, investigate first)
 

--- a/docs/architecture/vm-lifecycle-hardening/IMPLEMENTATION_PLAN.md
+++ b/docs/architecture/vm-lifecycle-hardening/IMPLEMENTATION_PLAN.md
@@ -518,7 +518,7 @@ the three remove-actions) a stale-snapshot read that would produce visibly wrong
 sequence needed to establish this is real, and this session's earlier click-flakiness with the
 desktop build (`docs/frictions.md`, 2026-08-29) made another live-repro attempt low-value.
 
-### 11. UiState-leak and derived-property convention (actionable — checklist step 7, investigate first)
+### 11. UiState-leak and derived-property convention (done — checklist step 7, see CHECKLIST-DONE.md)
 
 Source: *Sealed State vs. Data State* (2026-08-09), re-read 2026-08-29. Finding 6 already validated
 this article's headline claim (data class over sealed hierarchy — this project already does that),
@@ -526,22 +526,49 @@ but two more specific sub-claims from the same article weren't checked yet:
 
 1. **UiState ≠ State ("UI-decision leak").** The article's point survives the sealed-vs-data choice:
    a field is a leak if it encodes a *rendering* decision (e.g. a raw `isEmpty: Boolean` the
-   ViewModel computed) rather than raw data the UI itself should decide how to interpret. Not yet
-   checked whether any `FeatureState` in this codebase has a field like that, versus deriving such
-   booleans from raw fields.
+   ViewModel computed) rather than raw data the UI itself should decide how to interpret.
 2. **Derived `get()` properties for UI-only booleans.** The article's fix keeps rendering-decision
    booleans as computed `get()` properties on the State class (not stored fields, not recomputed
    inline in a Composable/mapper) — removing one shouldn't force a ViewModel rebuild or test rewrite.
-   Not yet checked whether this convention is actually followed anywhere in this codebase, or
-   whether equivalent logic instead lives inline in Composables or in separate mapper functions.
 
-Approach: static grep pass over `*State.kt` classes for (a) boolean/enum fields whose name reads as
-a rendering decision rather than raw data (`isEmpty`, `showX`, `xVisible`-shaped names that aren't
-already `get()` properties) and (b) existing `get()` properties on State classes, to see whether the
-convention already exists in places and is just inconsistent, or is absent entirely. Only look at
-live behavior/tests for whichever candidates the grep surfaces, not a blanket sweep.
+**Static-grep pass over all 37 `*State.kt` files under `feature/*/ui`.** No violation of sub-claim 1
+found. Grepped for `isXxxEmpty`/`showXxx`/`isXxxVisible`-shaped fields: the only matches are
+`isXxxDialogVisible`/`isXxxAlertVisible` (SettingsState, SprintState, IssueDetailsState,
+TrustedCertificatesState, WikiBookmarksState, TagsScreenState, ProjectValuesState, WikiPagesState,
+LoginState, EpicDetailsState, and the `EditXxxState`/`SprintDialogState` family) — these are genuine
+raw UI state (a user directly opens/closes a dialog; nothing else in the same State class determines
+that), not a derived rendering decision duplicating another field. No `isEmpty`-shaped field exists
+anywhere, stored or derived — list screens (`WikiPagesState.allPages`, `KanbanState.stories`, etc.)
+don't store an emptiness flag at all.
 
-Checklist step 7 scopes this as an investigation, not a commitment to change anything project-wide.
+**Sub-claim 2's convention already exists — in exactly the one place it's warranted, and via two
+different mechanisms this project already uses.** Only one `*State.kt` has a `get()` property:
+`CustomFieldItemState.isModified` (`originalValue != currentValue`). Checked its usages: referenced
+in `WorkItemCustomFieldsDelegateImpl`, three separate spots in `CustomFieldsWidget.kt` (indication
+color, save-button `enabled`, focus state), and a test assertion — five-plus call sites, genuinely
+avoiding a duplicated `originalValue != currentValue` computation. That matches both the article's
+convention **and** this project's own "no abstraction for single-use code" rule (CLAUDE.md, Coding
+Guidelines) — it earns the `get()` because it's actually multi-use, not by default.
+
+The other mechanism, used more often here than `get()` properties: **a shared widget that takes raw
+fields and computes the render-branch decision once, internally.** `WikiPagesScreen.kt` doesn't
+inline `allPages.isEmpty() && !isLoading`-shaped logic at all — it hands `items`/`isLoading`/`error`
+straight to `WikiListContentWidget`, which owns the branching. For the four Paging-backed list
+screens (Issues, Epics, Kanban, ScrumBacklog), the same de-duplication happens via extension
+functions in `utils/ui/.../PagingUtils.kt` — `LazyPagingItems<*>.hasError()`, `.isNotLoading()`,
+`.hasCompletedLoad()` — each defined once, called from every screen's `when` branch instead of each
+screen re-deriving the same `loadState` logic inline. This achieves the article's actual goal (don't
+duplicate a derived rendering decision in more than one place) through composition across screens
+rather than a computed property per State class — arguably a better fit for this project's
+widget-heavy architecture than adding a `get()` to every list `*State.kt`, since the derived logic
+is genuinely shared *across* screens, not just across call sites within one screen.
+
+**Conclusion: no violation, no action.** The convention this article argues for is already followed
+in substance — a `get()` property where reuse actually justifies it, a shared widget/extension where
+the same derived logic is needed by more than one screen, and no stored field anywhere that
+duplicates a UI-rendering decision the raw data already encodes. Not worth writing up as a new
+CLAUDE.md rule since it isn't a rule being missed — it's already how the code is structured, just not
+under this vocabulary.
 
 ## Candidate for agentic-grappim (project-agnostic, not TaigaMobileNova-specific)
 

--- a/docs/architecture/vm-lifecycle-hardening/IMPLEMENTATION_PLAN.md
+++ b/docs/architecture/vm-lifecycle-hardening/IMPLEMENTATION_PLAN.md
@@ -71,6 +71,69 @@ This is real, but scope matters before doing anything:
 the shared wrapper now for future use or add it per screen as needed, (c) whether it's even
 meaningful on iOS/Desktop targets or Android-only.
 
+**Resolved 2026-08-29:** (a) forms/entry-flow screens only, not list/detail; (b) build a shared
+reusable helper up front, not ad hoc per screen — `RestorableState` (`utils/ui`), a small
+`restore(key, default)` / `save(key, value)` wrapper around `SavedStateHandle`, kept deliberately
+thin rather than a `UiStateMachine`-style base class, since it composes with the existing
+`FeatureState` data-class + `_state.update { }` convention instead of replacing it; (c) not
+resolved — see the blocking finding below.
+
+**Technical groundwork done (pilot: `CreateTaskViewModel`):**
+- `SavedStateHandle` is KMP-ready via the already-pinned `jetbrainsAndroidxLifecycle` (2.11.0)
+  train — `org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-savedstate` (new catalog entry
+  `jetbrains-lifecycle-viewmodel-savedstate`, added to `KmpCompose.kt` alongside the other two
+  lifecycle/savedstate deps it already applies project-wide). Real per-target implementation ships
+  under the plain `androidx.lifecycle` group coordinates with per-target classifiers (`-desktop`,
+  `-iosarm64`, …) — the `org.jetbrains.androidx.lifecycle` artifact is a thin Gradle Module
+  Metadata redirect to those, the same pattern already seen for `androidx.navigation3`.
+- Koin's `koinViewModel()` (`org.koin.compose.viewmodel`, via `koin-core-viewmodel`'s
+  `AndroidParametersHolder`) auto-resolves a plain `SavedStateHandle` constructor parameter on any
+  `@KoinViewModel` — no `single { }` registration, no `@InjectedParam` needed. Confirmed by reading
+  `AndroidParametersHolder.elementAt`/`getOrNull`, which special-case the `SavedStateHandle` type
+  and call `extras.createSavedStateHandle()`. This requires the resolved `CreationExtras` to carry
+  a `SavedStateRegistryOwner`.
+- This project's Nav3 decorator wiring (`NavigationState.kt`'s `toEntries()`) already satisfies
+  that: `rememberSaveableStateHolderNavEntryDecorator()` runs before
+  `rememberViewModelStoreNavEntryDecorator<NavKey>()`, which is exactly the order
+  `ViewModelStoreNavEntryDecorator`'s own doc comment requires ("This requires the usage of
+  SaveableStateHolderNavEntryDecorator to ensure that the NavEntry scoped ViewModels can properly
+  provide access to SavedStateHandles").
+- `CreateTaskViewModel` now takes a `savedStateHandle: SavedStateHandle` param, wraps it in
+  `RestorableState`, and restores/persists `title`/`description` through it. Compiles clean;
+  `RestorableStateTest` (`utils/ui`) and new `CreateTaskViewModelTest` cases (restore-from-prior-handle,
+  save-persists-to-handle) pass; full `jvmTest` and `ktlintCheck` are green; `KoinGraphTest` shows
+  no new `NoDefinitionFoundException` (though that test can't fully prove the constructor-param
+  resolution path — its `route`-first `DefinitionParameterException` short-circuits before
+  `savedStateHandle` would ever be evaluated, since Kotlin evaluates constructor args left to right).
+
+**Blocking finding (2026-08-29, emulator-verified — see `docs/EMULATOR_TESTING.md`):** the Nav3
+back stack itself does not survive a real process kill in this app. Reproduced: logged in,
+navigated to the Create Task screen, typed distinct title/description, backgrounded
+(`KEYCODE_HOME`), killed the process (`am kill`, confirmed dead via `ps`), relaunched onto the same
+task (`am start -n`, confirmed a genuine restore via `dumpsys activity activities`'s `sz=1`, not a
+fresh activity). The app landed on **Dashboard** — its post-login start destination — not back on
+Create Task, despite the login session itself surviving. **This means the
+`CreateTaskViewModel`/`RestorableState` wiring above is currently inert in practice**: a user killed
+mid-form never gets back to the form to see the restored fields at all. The per-ViewModel
+`SavedStateHandle` piece was necessary but is not sufficient — the back stack has to survive the
+same process death first, or this delivers no observable benefit regardless of how many screens it's
+added to.
+
+Root cause not yet investigated. Candidates: `MainActivity`'s `setContent` call not receiving/using
+`savedInstanceState`, or `rememberNavigationState`'s `SavedStateConfiguration` param not actually
+being wired to real Activity-level bundle persistence (it may only be surviving
+recomposition/configuration change via `rememberSaveable`, not a true process kill). Needs its own
+investigation before this checklist step can be called done — (c) above (iOS/Desktop meaningfulness)
+is moot until this is fixed, since Android is the only platform where "process death" is even a
+distinct event to test against.
+
+**Decided 2026-08-29:** option 1 — investigate and fix the back-stack restoration gap first, as its
+own task, in a new session, before anything else on this initiative. The `CreateTaskViewModel`/
+`RestorableState` change already built lands now as correct, tested infrastructure with the caveat
+above documented; it becomes real end-to-end value once the back-stack fix lands, with no further
+VM-level work needed for that one screen. Rolling the same pattern out to other form screens stays
+parked until the back-stack gap is fixed — no further screens should pick this up in the meantime.
+
 ### 3. Concurrent independent loads in `init` (declined — no action)
 
 Source: *How to load ViewModel's data without using 'init'* (2026-07-19), specifically its Issue 1

--- a/docs/architecture/vm-lifecycle-hardening/IMPLEMENTATION_PLAN.md
+++ b/docs/architecture/vm-lifecycle-hardening/IMPLEMENTATION_PLAN.md
@@ -508,7 +508,7 @@ Every case is: an `areXxxLoading`/`isXxxLoading` flag already exists in state an
 as a loading spinner, but the actionable button(s)/icon(s) are gated only by `isOffline`, not by that
 loading flag too. Step 4's fix (`isOffline = isOffline || state.areXxxLoading`) is a direct, one-line
 template at each site — no new investigation needed to know *what* the fix looks like, just where to
-apply it. Not applied here (step 6 is investigate-only) — proposed as new checklist step 8.
+apply it. Not applied here (step 6 is investigate-only) — applied as checklist step 8.
 
 No live reproduction done for these three (unlike step 4's original, which also wasn't live-verified
 before its fix — see finding 8 — and unlike step 5, where live reproduction was the only way to

--- a/docs/architecture/vm-lifecycle-hardening/IMPLEMENTATION_PLAN.md
+++ b/docs/architecture/vm-lifecycle-hardening/IMPLEMENTATION_PLAN.md
@@ -209,10 +209,33 @@ synchronously), the nondeterministic-ordering failure mode the article describes
 here. The one Turbine usage in that test file (`snackBarMessage.test { awaitItem() }`) asserts a
 single one-off event, not multiple ordered state emissions.
 
-**No action.** Worth remembering if a future test on one of these VMs switches to asserting an
-ordered sequence of `state.test { awaitItem() }` calls instead of a final `.value` snapshot — that
-would reintroduce the exact flakiness this article describes. The fix in that case is to assert the
-final state instead, not to restructure the VM's `init`.
+That covers why the *tests* don't flake — a separate question is whether the concurrency itself is
+still a production correctness risk even though the tests can't see one. It isn't, for two
+structural reasons, both confirmed against `EpicsViewModel.kt`:
+
+- **The two launches write disjoint state fields.** `loadFiltersData()` only touches
+  `isFiltersLoading`/`filtersError`/`filters`; `getPermissions()` only touches `canAddEpic`. Each
+  write goes through `StateFlow.update {}`, which is atomic. With no shared field between them,
+  whichever coroutine finishes first, the final state converges to the same value regardless of
+  interleaving — there is nothing for "order" to corrupt. The other 7 VMs in the list above were
+  found by this same shape (`init` firing two independent `launch` blocks onto separate fields), so
+  this generalizes by construction, though only Epics was opened to confirm it directly.
+- **`viewModelScope` is a `SupervisorJob`, so the two launches fail independently.** Confirmed from
+  `androidx.lifecycle`'s own `commonMain` source
+  (`androidx/lifecycle/viewmodel/internal/CloseableCoroutineScope.kt`, shared across
+  Android/iOS/JVM): `CloseableCoroutineScope(coroutineContext = dispatcher + SupervisorJob())`. An
+  unhandled exception in one `init`-launched coroutine cannot cancel its sibling — each is already
+  wrapped in its own `resultOf`/try-catch regardless.
+
+**No action** — confirmed as a non-issue on both axes: the test-flakiness question the article
+raises, and the underlying production-correctness question it doesn't directly ask but which the
+"is this actually broken?" framing implies. Worth remembering if a future test on one of these VMs
+switches to asserting an ordered sequence of `state.test { awaitItem() }` calls instead of a final
+`.value` snapshot — that would reintroduce the exact flakiness this article describes. The fix in
+that case is to assert the final state instead, not to restructure the VM's `init`. Revisit the
+production-correctness argument specifically if a future VM in this shape ever writes the *same*
+field from two independent `init` launches — disjoint fields is what makes ordering irrelevant
+here, and that would no longer hold.
 
 ### 4. Constructor-injected initial state (OTOS) (actionable — checklist step 3, investigate first)
 

--- a/docs/architecture/vm-lifecycle-hardening/IMPLEMENTATION_PLAN.md
+++ b/docs/architecture/vm-lifecycle-hardening/IMPLEMENTATION_PLAN.md
@@ -593,7 +593,11 @@ duplicates a UI-rendering decision the raw data already encodes. Not worth writi
 CLAUDE.md rule since it isn't a rule being missed — it's already how the code is structured, just not
 under this vocabulary.
 
-## Candidate for agentic-grappim (project-agnostic, not TaigaMobileNova-specific)
+## Written up in agentic-grappim (project-agnostic, not TaigaMobileNova-specific)
+
+**Done 2026-08-30** — both items below are now in the shared `mobile-patterns` skill
+(`agentic-grappim/skills/mobile-patterns/SKILL.md`), not just flagged here. Kept below as the
+original evidence trail.
 
 While digging into finding 1 (2026-08-29 discussion), worked out the actual platform-dependent
 behavior of an unhandled root-coroutine exception with no `CoroutineExceptionHandler` — this is

--- a/docs/architecture/vm-lifecycle-hardening/IMPLEMENTATION_PLAN.md
+++ b/docs/architecture/vm-lifecycle-hardening/IMPLEMENTATION_PLAN.md
@@ -253,6 +253,36 @@ Checklist step 3 scopes this as an investigation: prototype the pattern on one c
 form VM (pick the one with the most setter-chaining in its existing tests) before deciding whether
 to generalize it as a project convention.
 
+**Resolved 2026-08-29: declined — no constructor change needed.** Grepped every `*ViewModelTest.kt`
+for the longest single-test chain of `onXChange`/`setX` calls; `ProjectDetailsViewModelTest`'s
+`onSaveClick - success` test had the worst offender in the codebase (6 chained setters to build one
+target `ProjectDetailsState` before asserting the save). Prototyped fixing it two ways, without
+touching any production code:
+
+- **`ProjectDetailsViewModelTest`** (repo-loaded form): `save()` reads `_state.value`, and `init`
+  copies the fake's `getProjectDetailsResult` straight into that state. Configuring the fake to
+  return the *target* state directly (`details(name = "edited", ...)`) reaches it in one step —
+  the fake's return value already **is** the constructor-time seam OTOS wants `initialState` for.
+  Deleted the six `onXChange`/`onIsXChange` calls entirely; test still passes
+  (`./gradlew :feature:settings:ui:jvmTest --tests "*ProjectDetailsViewModelTest*"`).
+- **`CreateTaskViewModelTest`** (route/`SavedStateHandle`-driven form, no repo load in `init`):
+  `onCreateTask - success` used to chain `setTitle`+`setDescription`. Pre-seeding the constructor's
+  `SavedStateHandle` with `mapOf("title" to "...", "description" to "...")` reaches the same target
+  state in one step, since state-init already calls `restorableState.restore(KEY, "")` against it —
+  the same trick checklist step 2's process-death test already exercised, just not yet reused here.
+
+Both are shapes the plan above called out as *not* needing `initialState` injection
+("load-and-display VMs... tests already reach the state under test in one line by configuring a
+fake's return value") and one it called out as a genuine form VM. The form-VM case turned out to
+resolve the same way once its actual state-construction path (repo fake / `SavedStateHandle`) was
+traced, rather than assuming `onXChange` calls were the only way in. **No VM examined lacked an
+existing collaborator-based seam** (fake repository result, `SavedStateHandle` initial map, route
+nav-args) sufficient to reach any target state in one step. Adding a dedicated `initialState`
+constructor parameter would duplicate that path, not remove setup cost — it's a second, competing
+way to set values the VM can already receive at construction time. Declining to adopt it as a
+convention; both simplified tests are kept as the fix for the two worst chains found, without any
+production-code change.
+
 ### 5. `AppInfoProvider.isDebug()` runtime facade (declined — no action)
 
 Source: *How to keep debug code out of release builds* (2026-08-23).

--- a/docs/architecture/vm-lifecycle-hardening/IMPLEMENTATION_PLAN.md
+++ b/docs/architecture/vm-lifecycle-hardening/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,379 @@
+# ViewModel Lifecycle & Error-Handling Hardening — Implementation Plan
+
+## Background
+
+Gregory forwarded 8 articles from the "Android Lead" newsletter (Mykhailo Vasylenko), covering VM
+`init`, process-death state restoration, testability, State design, startup-task DI, debug-code
+isolation, and silent coroutine exceptions. A 9th, *Why your MVI can't handle two Intents at once*
+(2026-07-05), was added later. Every post ends
+with the same pitch for a paid "Production-Ready MVI" course — the technical claims were checked
+against this codebase rather than taken at face value. Most don't map cleanly onto this project's
+architecture (KMP + Koin + hand-rolled MVVM per CLAUDE.md, not single-platform Android + Hilt +
+MVI), but three produced confirmed, concrete findings worth fixing.
+
+## Findings
+
+### 1. Silent exceptions on `ApplicationScope` (actionable — checklist step 1)
+
+Source: *"No crashes" doesn't mean your Android app is healthy* (2026-06-14).
+
+`core/async-kmp/src/commonMain/kotlin/com/grappim/taigamobile/core/asynckmp/KmpCorotuinesModule.kt:46-47`:
+
+```kotlin
+@[Single ApplicationScope]
+fun provideApplicationScope(@DefaultDispatcher defaultDispatcher: CoroutineDispatcher): CoroutineScope =
+    CoroutineScope(SupervisorJob() + defaultDispatcher)
+```
+
+No `CoroutineExceptionHandler` in the context. Two production call sites launch on this scope with
+nothing catching failures:
+
+- `AuthStateManager.logout()` (`core/storage/src/commonMain/kotlin/com/grappim/taigamobile/core/storage/auth/AuthStateManager.kt:34-38`)
+  — if `clearAllTables()` or any storage-clear step throws, the user believes they logged out but
+  data wasn't cleared and `_logoutEvents` never fires. No log, no crash.
+- `TaigaApp.onCreate()` (`androidApp/src/main/kotlin/com/grappim/taigamobile/TaigaApp.kt:55-61`) —
+  `cacheManager.cleanExpiredCache()` and the crash-reporting-toggle flow
+  (`taigaSessionStorage.crashReportingEnabled.onEach { ... }.launchIn(applicationScope)`) both run
+  unguarded.
+
+This is a direct violation of CLAUDE.md's Error Handling rule ("never swallow exceptions
+silently"). The fix is small and self-contained: add a handler to the scope provider — no call-site
+changes needed, since `SupervisorJob` already isolates failures from each other; the handler just
+needs to make them visible via `logcat`.
+
+### 2. Process-death UI-state restoration (gated — checklist step 2)
+
+Source: *How to avoid losing UI State after process death* (2026-06-21), reinforced by *Why your
+ViewModel is untestable* (2026-06-28), which builds its `initialState`-via-constructor-injection fix
+on the same `UiStateMachine`/`SavedStateHandle` wrapper.
+
+Grepped: `SavedStateHandle` appears nowhere in production code
+(`grep -rl "SavedStateHandle" --include="*.kt" feature core composeApp` returns one hit — a test
+file's own filename, not a real usage). Every VM's `MutableStateFlow` resets to its hardcoded
+default on process death; nothing restores it.
+
+This is real, but scope matters before doing anything:
+
+- Not every screen needs it — a list/detail screen that just re-fetches from the server on
+  restoration loses nothing a user would notice. The article's own examples (onboarding, checkout,
+  multi-step forms) are screens where a user has *entered* data a re-fetch can't recover.
+- The proposed mechanism (`Parcelable` state class + a `UiStateMachine` wrapper around
+  `SavedStateHandle`, exposing `isStateRestored` so `init` can skip a reload) is a new shared
+  abstraction this project doesn't have. Introducing it project-wide up front vs. adding it
+  ad hoc to specific screens as they're touched is a real design choice, not a one-line fix.
+- Route params are already passed via Koin `@InjectedParam` (see CLAUDE.md's Navigation Pattern),
+  not `SavedStateHandle.toRoute()` — a `UiStateMachine` wrapper would need its own
+  `SavedStateHandle` injection path alongside that, which is a KMP-compatibility question worth
+  checking early (does `SavedStateHandle` exist as a meaningful concept outside Android?) before
+  committing to the pattern as described in the article.
+
+**Gated on gregory** picking: (a) which screens/flows actually warrant this, (b) whether to build
+the shared wrapper now for future use or add it per screen as needed, (c) whether it's even
+meaningful on iOS/Desktop targets or Android-only.
+
+### 3. Concurrent independent loads in `init` (declined — no action)
+
+Source: *How to load ViewModel's data without using 'init'* (2026-07-19), specifically its Issue 1
+(flaky Turbine tests from nondeterministic coroutine ordering when `init` fires more than one
+concurrent load).
+
+Searched for ViewModels whose `init` block calls 2+ independently-launching functions:
+
+```
+feature/epics/.../EpicsViewModel.kt              -> loadFiltersData(), getPermissions()
+feature/issues/.../IssuesViewModel.kt            -> loadFiltersData(), getPermissions()
+feature/kanban/.../KanbanViewModel.kt             -> getKanbanData(), loadFiltersData()
+feature/scrum/.../ScrumBacklogViewModel.kt        -> loadFiltersData(), getPermissions()
+feature/settings/.../ProjectValuesViewModel.kt    -> loadItems(), loadPresetColors()
+feature/settings/.../TagsScreenViewModel.kt       -> fetchTagsColors(), initDialogTags()
+feature/workitem/.../WorkItemEditTagsViewModel.kt -> fetchTags(), initDialogTags()
+feature/workitem/.../EditSprintViewModel.kt       -> getPermissions(), getSprints()
+```
+
+Each fires two independent `viewModelScope.launch` blocks from `init`, updating disjoint state
+fields — exactly the shape the article warns about (confirmed by reading `EpicsViewModel.kt` in
+full: `loadFiltersData()` and `getPermissions()` are each their own `launch`, no ordering between
+them).
+
+Checked `EpicsViewModelTest.kt` as the representative case — tests assert `sut.state.value` (a
+snapshot taken after `createViewModel()` returns), not an ordered sequence of Turbine-collected
+emissions. Combined with `MainDispatcherRule`'s unconfined test dispatcher (both `init`-launched
+coroutines run to completion before `createViewModel()` returns, since the fakes they call resolve
+synchronously), the nondeterministic-ordering failure mode the article describes doesn't arise
+here. The one Turbine usage in that test file (`snackBarMessage.test { awaitItem() }`) asserts a
+single one-off event, not multiple ordered state emissions.
+
+**No action.** Worth remembering if a future test on one of these VMs switches to asserting an
+ordered sequence of `state.test { awaitItem() }` calls instead of a final `.value` snapshot — that
+would reintroduce the exact flakiness this article describes. The fix in that case is to assert the
+final state instead, not to restructure the VM's `init`.
+
+### 4. Constructor-injected initial state (OTOS) (actionable — checklist step 3, investigate first)
+
+Source: *Why your ViewModel is untestable* (2026-06-28). It coins its own rule, "OTOS — one test,
+one state" (a corollary to the existing, non-newsletter-original "OTOA — one test, one assertion"
+principle it cites first): a test should reach the state it's checking in one step, not by chaining
+several setter calls. Its fix is to inject `initialState` via the ViewModel's constructor (defaulted
+so existing call sites don't break), so a test can do
+`createObjectUnderTest(initialState = RegisterUiState(email = "...", password = "...", ...))` in one
+line instead of four sequential `viewModel.onXChanged(...)` calls.
+
+That article itself cites a second source worth reading alongside it: *The Importance of One Test
+One Assertion (OTOA) in Unit Testing* (DaniG, Treatwell Product Engineering Blog, 2025-03-02). It
+refines OTOA more precisely than the newsletter's shorthand: the rule is one test asserts one
+*behaviour*, not literally one assertion call — a single `assertThat(padawan).extracting("lightsaberColor", "dexterity", "name", "planetOfOrigin")`
+still violates OTOA even though it's syntactically one statement, because it checks several
+unrelated behaviours at once. Worth keeping that distinction in mind, since it's easy to satisfy
+OTOA's letter (one `assertX` call) while missing its point (one behaviour under test).
+
+Assessed 2026-08-29: mixed value for this codebase, not a uniform win.
+
+- **Doesn't help** this project's common load-and-display VMs (`SettingsUserScreenViewModel`-shaped
+  screens) — tests already reach the state under test in one line by configuring a fake's return
+  value before calling `createViewModel()`. Injecting `initialState` would just relocate that one
+  line, not remove setup cost.
+- **Would genuinely help** multi-field form/edit screens (create task, edit sprint, and similar)
+  where a test currently chains several `viewModel.onXChanged(...)` calls to reach the one state
+  combination it's checking — the exact shape the article's four-setter register-form example
+  complains about.
+- **Not a uniform one-line change** the way the article's toy example implies: several of this
+  project's VMs compute part of their default state from injected repos/storage at construction
+  time (e.g. `SettingsUserScreenViewModel` derives `isUnencryptedConnection` from
+  `serverStorage.server`) rather than a bare `RegisterUiState()`. Adding `initialState` injection to
+  those would need per-VM thought about how the derived fields and the injected default interact,
+  not a blanket constructor-signature change.
+
+Checklist step 3 scopes this as an investigation: prototype the pattern on one concrete multi-field
+form VM (pick the one with the most setter-chaining in its existing tests) before deciding whether
+to generalize it as a project convention.
+
+### 5. `AppInfoProvider.isDebug()` runtime facade (declined — no action)
+
+Source: *How to keep debug code out of release builds* (2026-08-23).
+
+`androidApp/src/main/kotlin/com/grappim/taigamobile/data/AppInfoProviderImpl.kt:13` wraps
+`BuildConfig.DEBUG` behind a runtime-injected `AppInfoProvider` interface, used in `TaigaApp.kt`
+(Timber tree selection, StrictMode setup) and `ImageLoaderProvider.kt` — exactly the anti-pattern
+the article flags (R8 can't dead-code-eliminate a value that comes from the runtime DI graph the
+way it can a true compile-time constant).
+
+Declined: the article's fix is Android build-type source sets (separate `debug`/`release` DI
+modules providing different implementations). That doesn't generalize to this project's iOS and
+JVM/desktop targets — those platforms have no equivalent of an Android build type, so the facade
+exists *because* this is KMP, not despite it (see `AppInfoProviderImpl.jvm.kt` and
+`AppInfoProviderImpl.ios.kt`, each with their own platform-appropriate debug check). Revisit only if
+this ever becomes a measured R8-size or test-coverage problem in practice on the Android target
+specifically.
+
+### 6. State design (validated — no action)
+
+Source: *Sealed State vs. Data State* (2026-08-09). This project's `FeatureState` data-class
+convention (CLAUDE.md's "ViewModel + State Pattern") already matches the article's recommendation
+over a sealed-hierarchy state design. Nothing to change; kept here only so a future session doesn't
+re-derive the same check.
+
+### 7. Not applicable to this architecture
+
+- *How to load ViewModel's data without using 'init'* (2026-07-19, the Startup-Intent pattern
+  itself) and *How to remove 90% of Android app initialization logic and follow SRP principle*
+  (2026-07-26, the Startup Task multibinding pattern) both presuppose an MVI Intent/reducer pipeline
+  or Hilt-style multibinding this project doesn't have (Koin `@ComponentScan`, plain MVVM per
+  CLAUDE.md). Neither is a drop-in fix without first adopting MVI as an architecture — a much larger
+  decision than either article implies.
+
+  **Queued (not started):** the second article's "the module graph pays for it" claim hasn't been
+  checked against this codebase's actual Gradle graph yet — only the architectural-mismatch argument
+  above has been assessed. Worth checking whether `composeApp` (the entry-point-equivalent module)
+  shows the same ":app depends on everything" shape, and if so, whether it comes from the same cause
+  the article describes (ad hoc per-feature startup-preload dependencies piling up in one class) or
+  from something else (e.g. Koin's DI-module aggregation, or Nav3 screen-graph wiring) that the
+  article's `StartupTask` fix wouldn't touch either way.
+- *MVP vs MVVM vs MVI* (2026-08-02) is purely conceptual/historical — no codebase claim to check.
+- The custom FIFO `flatMapConcurrently` operator, `scan`-based reducer, and abstract `MviViewModel`
+  base class from *Why your MVI can't handle two Intents at once* (2026-07-05) — same reason as
+  above, presupposes an Intent/reducer pipeline this project doesn't have. But unlike the other two,
+  this article's underlying claim (two independent async writes to the same `StateFlow` can land
+  out of submission order, "last write wins") isn't itself MVI-specific, and checking it against the
+  codebase turned up a real instance — see finding 8 / checklist step 4.
+
+### 8. Watch/unwatch last-write-wins race (actionable — checklist step 4)
+
+Source: *Why your MVI can't handle two Intents at once* (2026-07-05). Its running example: a
+banking screen where "pay" and "cancel" are two independent async actions on the same resource: the
+last network response to land wins, regardless of which the user tapped last or which the user
+tapped at all after the first.
+
+Checked whether this project has any comparable pair of independent, overlapping async writes to
+the same state field. `WorkItemWatchersDelegateImpl`
+(`feature/workitem/ui/src/commonMain/kotlin/com/grappim/taigamobile/feature/workitem/ui/delegates/watchers/WorkItemWatchersDelegateImpl.kt`)
+has exactly this shape:
+
+- `handleAddMeToWatchers` (watch) and `handleRemoveMeFromWatchers` (unwatch) are each `suspend`
+  functions called from their own independent `viewModelScope.launch` block
+  (`TaskDetailsViewModel.onAddMeToWatchersClick` / `onRemoveMeFromWatchersClick:658-670`, and the
+  same pair in `UserStoryDetailsViewModel`, `EpicDetailsViewModel`, `IssueDetailsViewModel` — all
+  four detail screens share this delegate).
+- Each does a multi-step async chain (watch/unwatch API call → `getUpdateWorkItem` →
+  `getUsersList`) before writing `_watchersState.update { it.copy(..., isWatchedByMe = result.isWatchedByMe) }`.
+  No versioning or cancellation-of-prior-request guards the write.
+- The watch/unwatch button
+  (`feature/workitem/ui/src/commonMain/kotlin/com/grappim/taigamobile/feature/workitem/ui/widgets/WatchersWidget.kt:92-103`)
+  is never disabled while `watchersState.areWatchersLoading` is true — it only checks `isOffline`
+  (`TaigaTextButtonWidget`'s `enabled = !isOffline`, no loading param). So the double-tap that
+  creates the race is directly reachable: watch, then unwatch before the first request returns —
+  whichever response lands second overwrites `isWatchedByMe` with its own (possibly stale) result.
+
+**Confirmed real, contradicts the initial read that this article had nothing useful.** The fix does
+not require adopting the article's own machinery (custom `flatMapConcurrently`, `scan` reducer,
+abstract `MviViewModel` base class, `UiStateMachine`) — this project's plain MVVM pattern can close
+the race the simpler way: prevent the overlapping requests from firing at all. Pass
+`isOffline = isOffline || watchersState.areWatchersLoading` to the watch/unwatch
+`TaigaTextButtonWidget` call in `WatchersWidget.kt` — reuses the existing disabled-button visual,
+one line, no new prop.
+
+**Secondary source (2026-08-29):** *What Are Optimistic Updates?* (Kyle DeGuzman, Medium,
+2022-11-16) — cited by the SRP-init article ("Authorized + non-blocking... can run optimistically"),
+generic front-end concept, not Android-specific: update the UI immediately assuming success, revert
+and show an error if the server rejects it; its own guidance is to use this for binary,
+low-consequence actions (its worked example is literally Like/Unlike) and to avoid it where a revert
+would cascade elsewhere.
+
+Watch/unwatch is exactly that shape, and this codebase already has a full implementation of the
+pattern elsewhere: `KanbanViewModel.moveStory()`
+(`feature/kanban/ui/src/commonMain/kotlin/com/grappim/taigamobile/feature/kanban/ui/KanbanViewModel.kt:190-236`)
+updates `_state` immediately on drag-and-drop reorder, fires the network call, and reverts to
+`previousStoriesByStatus` plus surfaces an error on failure (`computeOptimisticUpdate` at line 238).
+So watch/unwatch's current blocking implementation (spinner, wait for the full round trip) is
+inconsistent with a convention this project already uses for a comparable low-consequence toggle —
+worth considering as a *further* option for checklist step 4, beyond just disabling the button:
+flip `isWatchedByMe` immediately and revert on failure, the same shape as `moveStory()`. Not
+folded into step 4's fix directly — the disable-button fix alone already closes the race with a
+one-line change; going optimistic is a separate, larger step (still needs the same overlap guard,
+or a rethink of it, to avoid two optimistic toggles racing the same way) and hasn't been scoped.
+Noting it here as an option to weigh when step 4 is picked up, not committing to it.
+
+### 9. Redundant `init`-time re-fetches of already-known/rarely-changing data (actionable — checklist step 5, investigate first)
+
+Source: *How to load ViewModel's data without using 'init'* (2026-07-19), its Issue 3 ("Customer
+that never returns") — distinct from finding 3 above, which only checked that article's Issue 1
+(test flakiness). Issue 3's argument: unconditionally re-running an `init`-time load on every VM
+reconstruction, even for data that already loaded successfully and rarely changes, creates an
+avoidable failure window — a transient network blip on the re-fetch turns a screen that *was* fine
+into an error, for data that didn't need re-fetching at all. The article frames this as a direct
+revenue-loss argument ("Any error, any additional click, any lost state - it's an additional user
+action, which always leads to revenue loss. → Don't rely on perfect network conditions. Avoid
+requests as much as you can.").
+
+This is a different root cause from checklist step 2 (process-death loses *user-entered* input) —
+Issue 3 is about read-only/rarely-changing data getting needlessly re-risked on *any* VM
+reconstruction, not specifically process death.
+
+Candidates already surfaced by finding 3's grep (same VMs, different reason this time):
+`EpicsViewModel`, `IssuesViewModel`, `KanbanViewModel`, `ScrumBacklogViewModel`,
+`EditSprintViewModel` all unconditionally call `getPermissions()` from `init` — permissions rarely
+change mid-session, so every re-entry into these screens re-risks a network call that already
+succeeded once, for data that's very unlikely to have changed.
+
+Its implementation guideline (`MviConfig`, startup-vs-user Intent naming convention,
+`@Restartable`-annotation filtering, abstract `MviViewModel` base class) is not applicable here —
+same reason as findings 7/8: presupposes the MVI Intent/reducer pipeline this project doesn't have.
+
+**Approach agreed with gregory (2026-08-29):** finding candidates is a static-grep pass — does the
+`init`-time load fetch data that's already known or unlikely to change (permissions, nav-arg data,
+an already-cached repository read)? That doesn't need live reproduction to enumerate. Only reproduce
+live (emulator, airplane-mode toggle around a re-navigation) on the one or two candidates actually
+picked, to confirm the UX regression is real — not as a blanket sweep across every VM.
+
+Checklist step 5 scopes this as an investigation, not a commitment to change anything project-wide.
+
+### 10. Does the watch/unwatch race generalize? (actionable — checklist step 6, investigate first)
+
+Prompted by gregory re-reading finding 8 (2026-08-29): that finding confirmed one instance of
+"nothing defines update order, any method mutates any field from any coroutine" (the *Why your MVI
+can't handle two Intents at once* claim) — `WorkItemWatchersDelegateImpl`'s watch/unwatch race — but
+never swept the rest of the codebase for the same shape. It only checked "any comparable pair" that
+turned up while investigating watchers specifically, not every ViewModel/delegate.
+
+Claim to check: are there other places with two-or-more independent `viewModelScope.launch` blocks
+(or delegate-launched coroutines) that can write to overlapping state fields with no
+cancellation/versioning/ordering guard, reachable by a user firing both before the first resolves —
+the same last-write-wins shape as watch/unwatch?
+
+Approach (same static-first pattern as findings 3/9): grep for state classes/delegates with more
+than one independent `launch` site writing into the same `MutableStateFlow`/`_xxxState`, shortlist
+candidates by whether the UI actually exposes two overlapping triggers (a button pair, a
+toggle a user can double-tap, two rapid-fire actions on the same field) the way `WatchersWidget`
+does — not every concurrent write is reachable by a real double-action. Only reproduce live on
+whichever candidates survive the shortlist, not as a blanket sweep.
+
+Checklist step 6 scopes this as an investigation, not a commitment to fix anything beyond what step
+4 already covers.
+
+### 11. UiState-leak and derived-property convention (actionable — checklist step 7, investigate first)
+
+Source: *Sealed State vs. Data State* (2026-08-09), re-read 2026-08-29. Finding 6 already validated
+this article's headline claim (data class over sealed hierarchy — this project already does that),
+but two more specific sub-claims from the same article weren't checked yet:
+
+1. **UiState ≠ State ("UI-decision leak").** The article's point survives the sealed-vs-data choice:
+   a field is a leak if it encodes a *rendering* decision (e.g. a raw `isEmpty: Boolean` the
+   ViewModel computed) rather than raw data the UI itself should decide how to interpret. Not yet
+   checked whether any `FeatureState` in this codebase has a field like that, versus deriving such
+   booleans from raw fields.
+2. **Derived `get()` properties for UI-only booleans.** The article's fix keeps rendering-decision
+   booleans as computed `get()` properties on the State class (not stored fields, not recomputed
+   inline in a Composable/mapper) — removing one shouldn't force a ViewModel rebuild or test rewrite.
+   Not yet checked whether this convention is actually followed anywhere in this codebase, or
+   whether equivalent logic instead lives inline in Composables or in separate mapper functions.
+
+Approach: static grep pass over `*State.kt` classes for (a) boolean/enum fields whose name reads as
+a rendering decision rather than raw data (`isEmpty`, `showX`, `xVisible`-shaped names that aren't
+already `get()` properties) and (b) existing `get()` properties on State classes, to see whether the
+convention already exists in places and is just inconsistent, or is absent entirely. Only look at
+live behavior/tests for whichever candidates the grep surfaces, not a blanket sweep.
+
+Checklist step 7 scopes this as an investigation, not a commitment to change anything project-wide.
+
+## Candidate for agentic-grappim (project-agnostic, not TaigaMobileNova-specific)
+
+While digging into finding 1 (2026-08-29 discussion), worked out the actual platform-dependent
+behavior of an unhandled root-coroutine exception with no `CoroutineExceptionHandler` — this is
+general Kotlin/coroutines knowledge, not specific to this codebase, so it belongs in a shared
+skill/reference in `agentic-grappim` rather than only living here:
+
+- **JVM/Desktop**: falls through to the thread's default uncaught-exception handler, which just
+  prints the stack trace to `stderr` and lets that one pool thread die; the pool replaces it. Truly
+  silent in production — nobody's watching stderr.
+- **Android**: the OS installs a process-wide default `Thread.UncaughtExceptionHandler` at startup
+  that logs a "FATAL EXCEPTION" and kills the process. If a crash-reporting SDK (Crashlytics,
+  Bugsnag, etc.) is present, it chains onto that same handler — reports the exception as a
+  **fatal** crash, then still kills the process. So on Android this is generally *not* silent: it's
+  either a reported crash (SDK present) or a visible, unreported "app has stopped" (SDK absent) —
+  contrary to how some blog posts frame this as universally invisible. `SupervisorJob` itself has no
+  bearing on any of this — it only stops sibling coroutines/parent from being cancelled; it says
+  nothing about logging or crashing.
+- **iOS/Kotlin-Native**: an uncaught exception in a worker/coroutine similarly terminates the
+  process by default.
+
+Net: "add a `CoroutineExceptionHandler`" is universally good advice, but *why* differs by platform
+— on JVM it turns an invisible failure into a visible one; on Android/iOS it turns an app crash
+into a contained, logged failure. Worth a short shared note (or an addition to an existing
+coroutines-related skill) next time `agentic-grappim` gets touched, rather than only living in this
+project's plan doc.
+
+**Second candidate (2026-08-29, discussing finding 2):** the `UiStateMachine` pattern itself
+(`SavedStateHandle`-backed state holder exposing `isStateRestored`, so `init` can skip a reload
+that would otherwise stomp on just-restored state) is a reusable, project-agnostic
+MVVM/Compose best practice — not specific to TaigaMobileNova's architecture, just not yet adopted
+here. Worth writing up as a general pattern in `agentic-grappim` (what problem it solves, the
+shape of the wrapper, the `isStateRestored` gate) independent of whether/where this project ends
+up adopting it. Two caveats to carry into that write-up, both surfaced while assessing it for this
+project and probably relevant anywhere it's proposed:
+- The pattern as commonly described assumes single-platform Android + Hilt
+  (`@HiltViewModel constructor(savedStateHandle: SavedStateHandle)`) — worth checking case by case
+  whether `SavedStateHandle` is actually usable the same way in a KMP or non-Hilt-DI project before
+  presenting it as a drop-in recipe.
+- `@Parcelize` is the natural serialization choice for the state class, but doesn't play well with
+  `kotlinx-collections-immutable` types (`ImmutableList`, etc.) out of the box — worth noting
+  `@Serializable` + a JSON blob in the Bundle as the alternative for projects already on
+  kotlinx-serialization.

--- a/docs/architecture/vm-lifecycle-hardening/IMPLEMENTATION_PLAN.md
+++ b/docs/architecture/vm-lifecycle-hardening/IMPLEMENTATION_PLAN.md
@@ -134,6 +134,49 @@ above documented; it becomes real end-to-end value once the back-stack fix lands
 VM-level work needed for that one screen. Rolling the same pattern out to other form screens stays
 parked until the back-stack gap is fixed — no further screens should pick this up in the meantime.
 
+**Root cause found and fixed 2026-08-29 (step done).** Neither of the two candidates named above was
+it — Nav3's `rememberNavBackStack(configuration, ...)` restoration was never broken. The real cause:
+`MainNavHost`'s top-level `LaunchedEffect(initialNavState.isReady)` unconditionally called
+`navigator.navigateToDashboardAsTopDestination()` (a `resetTo(DashboardNavDestination)`, which wipes
+every nav section per `Navigator`'s own doc comment) on **every** cold app start where the user is
+logged in with a project selected — including a process-death relaunch, even when Nav3 had already
+restored a deeper back stack. This fired on every real cold start (first-ever launch and
+process-death relaunch look identical to this code), stomping the correctly-restored `CreateTask`
+entry down to bare `Dashboard` every time.
+
+Fix (`composeApp/.../main/MainNavHost.kt`): gate that reset on `navigationState.currentKey ==
+LoginNavDestination` (the seed value for `topLevelStack`/each sub-stack when nothing has diverged
+from it yet). A truly fresh app start (or first-ever login) is still sitting on the seeded `Login`
+entry when this effect runs, so the reset still fires and the skip-login-screen behavior is
+unchanged; a process-death relaunch that already restored a deeper entry has a different
+`currentKey`, so the reset is skipped and the restored stack survives.
+
+**Second bug found while verifying the fix on the emulator (fixed in the same change):** with the
+reset skipped, the app relaunched onto a **blank screen forever** — the restored `CreateTask` screen
+was actually rendering correctly underneath (confirmed via `uiautomator dump`, which found the
+restored title/description text in the view tree), but `installSplashScreen()`'s
+`keepOnScreenCondition` never released because `ScreenReadySignalController.signalReady()` is only
+called from the `Login`/`ProjectSelector`/`Dashboard` `entry<>` blocks in `MainNavHost.kt` — see its
+doc comment, which explicitly assumes the app always lands on one of those three. A restored deeper
+screen never composes any of those three entries, so the signal never fires. Fixed by calling
+`screenReadySignal.signalReady()` directly in the top-level `LaunchedEffect`'s `else` branch (the
+"already on the correct restored screen, no Login-flash risk to wait out" case) — `LocalScreenReadySignal.current`
+is read once at the top of `MainNavHost` for this.
+
+**Verified on the `Medium_Phone_API_36.1` AVD** (fdroid debug build): logged in with a project
+selected, navigated Dashboard → Backlog → new user story (Create Task) form, typed a distinct
+title/description, backgrounded (`KEYCODE_HOME`), killed the process for real (`am kill`, confirmed
+dead via `ps`), relaunched (`am start -n`, `sz=1` confirming a genuine task resume not a fresh
+activity). App landed directly back on the Create Task form with both fields intact and no stuck
+splash. Also re-verified the untouched fresh-start path (force-stop, relaunch with no deeper
+navigation) still lands cleanly on Dashboard with the splash dismissing normally. `jvmTest` and
+`ktlintCheck` both green.
+
+No `RestorableState` rollout to further screens was done as part of this step — that was already
+out of scope (see "Resolved 2026-08-29" above, parked pending this fix). It can now be picked up as
+its own task if wanted, since the back-stack restoration this depends on is confirmed working
+end-to-end.
+
 ### 3. Concurrent independent loads in `init` (declined — no action)
 
 Source: *How to load ViewModel's data without using 'init'* (2026-07-19), specifically its Issue 1

--- a/docs/architecture/vm-lifecycle-hardening/IMPLEMENTATION_PLAN.md
+++ b/docs/architecture/vm-lifecycle-hardening/IMPLEMENTATION_PLAN.md
@@ -332,7 +332,7 @@ re-derive the same check.
   out of submission order, "last write wins") isn't itself MVI-specific, and checking it against the
   codebase turned up a real instance — see finding 8 / checklist step 4.
 
-### 8. Watch/unwatch last-write-wins race (actionable — checklist step 4)
+### 8. Watch/unwatch last-write-wins race (done — checklist step 4, see CHECKLIST-DONE.md)
 
 Source: *Why your MVI can't handle two Intents at once* (2026-07-05). Its running example: a
 banking screen where "pay" and "cancel" are two independent async actions on the same resource: the

--- a/docs/frictions.md
+++ b/docs/frictions.md
@@ -53,3 +53,11 @@ deleted — see `finalize`.
   too. Cost several minutes of chasing a phantom app bug (assumed the shortcut was broken) before
   testing a plain key press and finding it worked. Fix: drop `--window` for `xdotool key` sends the
   same as for `type` — click/`windowactivate` the target first, then send the key bare.
+- 2026-08-29: `xdotool mousemove --window <id> X Y click 1` against the composeApp desktop window
+  registered only intermittently (roughly 1 in 5-6 attempts) — same exact coordinates, same target
+  button, sometimes toggled the UI and sometimes silently did nothing, with no error and the mouse
+  cursor visibly landing on target each time (`getmouselocation` confirmed). Not a coordinate/offset
+  problem (retried at several nearby offsets with the same flakiness) and not specific to one widget
+  (back-arrow nav and two other buttons all showed it). Gave up after ~10 attempts and verified step
+  4's fix via code read + `jvmTest`/`ktlintCheck` instead of a live click-through. Root cause not
+  found; worth a fresh look if this blocks a future GUI-verification step.

--- a/docs/frictions.md
+++ b/docs/frictions.md
@@ -64,3 +64,7 @@ deleted — see `finalize`.
 - 2026-08-29: guessed `diffuse` 0.3.0 download URL (`diffuse-0.3.0-binary.jar`) 404'd; the release
   asset is actually a `diffuse-0.3.0.zip` — checked via `gh`/GitHub releases API
   (`browser_download_url`) instead of guessing the filename pattern from the version tag.
+- 2026-08-30: `pip install pyyaml` reported "already satisfied" but `python3 -c "import yaml"` still
+  failed with `ModuleNotFoundError` — this machine's `python3` on PATH resolves to a linuxbrew
+  install (3.14) that doesn't see the apt-installed pyyaml under `/usr/lib/python3/dist-packages`.
+  Fixed by calling `/usr/bin/python3` explicitly for the one-off YAML-parse check.

--- a/docs/frictions.md
+++ b/docs/frictions.md
@@ -61,3 +61,6 @@ deleted — see `finalize`.
   (back-arrow nav and two other buttons all showed it). Gave up after ~10 attempts and verified step
   4's fix via code read + `jvmTest`/`ktlintCheck` instead of a live click-through. Root cause not
   found; worth a fresh look if this blocks a future GUI-verification step.
+- 2026-08-29: guessed `diffuse` 0.3.0 download URL (`diffuse-0.3.0-binary.jar`) 404'd; the release
+  asset is actually a `diffuse-0.3.0.zip` — checked via `gh`/GitHub releases API
+  (`browser_download_url`) instead of guessing the filename pattern from the version tag.

--- a/feature/settings/ui/src/commonTest/kotlin/com/grappim/taigamobile/feature/settings/ui/projectdetails/ProjectDetailsViewModelTest.kt
+++ b/feature/settings/ui/src/commonTest/kotlin/com/grappim/taigamobile/feature/settings/ui/projectdetails/ProjectDetailsViewModelTest.kt
@@ -184,21 +184,21 @@ internal class ProjectDetailsViewModelTest {
      * before the send (the `isSaving = false` update) has already happened once `awaitItem`
      * returns.
      *
-     * `save` reads `_state.value` rather than the loaded details, so the edits made here are what
-     * must reach the repository.
+     * `save` reads `_state.value` rather than a separately tracked "edited" value, and `init`
+     * copies the fake's result straight into that state — so configuring the fake's result to
+     * already be the target state reaches it in one step, with no `onXChange` chain needed.
      */
     @Test
     fun `onSaveClick - success - sends the edited state to the repository and navigates back`() = runTest {
-        projectsRepository.getProjectDetailsResult = details(name = "loaded", description = "loaded")
+        projectsRepository.getProjectDetailsResult = details(
+            name = "edited",
+            description = "edited description",
+            isPrivate = true,
+            isLookingForPeople = true,
+            lookingForPeopleNote = "join us",
+            isContactActivated = true
+        )
         createViewModel()
-        with(sut.state.value) {
-            onNameChange("edited")
-            onDescriptionChange("edited description")
-            onIsPrivateChange(true)
-            onIsLookingForPeopleChange(true)
-            onLookingForPeopleNoteChange("join us")
-            onIsContactActivatedChange(true)
-        }
 
         sut.navigateBack.test {
             sut.state.value.onSaveClick()

--- a/feature/workitem/ui/src/commonMain/kotlin/com/grappim/taigamobile/feature/workitem/ui/widgets/AssignedToWidget.kt
+++ b/feature/workitem/ui/src/commonMain/kotlin/com/grappim/taigamobile/feature/workitem/ui/widgets/AssignedToWidget.kt
@@ -117,7 +117,7 @@ private fun AssignedToWidget(
                     onRemoveAssigneeClick(item)
                 },
                 canModify = canModify,
-                isOffline = isOffline
+                isOffline = isOffline || isAssigneesLoading
             )
 
             if (index < assignees.lastIndex) {
@@ -160,7 +160,7 @@ private fun AssignedToWidget(
                     TaigaTextButtonWidget(
                         text = stringResource(buttonText),
                         icon = buttonIcon,
-                        isOffline = isOffline,
+                        isOffline = isOffline || isAssigneesLoading,
                         onClick = {
                             if (isAssignedToMe) {
                                 onUnassign?.invoke()

--- a/feature/workitem/ui/src/commonMain/kotlin/com/grappim/taigamobile/feature/workitem/ui/widgets/WatchersWidget.kt
+++ b/feature/workitem/ui/src/commonMain/kotlin/com/grappim/taigamobile/feature/workitem/ui/widgets/WatchersWidget.kt
@@ -92,7 +92,7 @@ fun WatchersWidget(
             TaigaTextButtonWidget(
                 text = stringResource(buttonText),
                 icon = buttonIcon,
-                isOffline = isOffline,
+                isOffline = isOffline || watchersState.areWatchersLoading,
                 onClick = {
                     if (watchersState.isWatchedByMe) {
                         onRemoveMeFromWatchersClick()

--- a/feature/workitem/ui/src/commonMain/kotlin/com/grappim/taigamobile/feature/workitem/ui/widgets/WatchersWidget.kt
+++ b/feature/workitem/ui/src/commonMain/kotlin/com/grappim/taigamobile/feature/workitem/ui/widgets/WatchersWidget.kt
@@ -57,7 +57,7 @@ fun WatchersWidget(
                     watchersState.onRemoveWatcherClick(item.actualId)
                 },
                 canModify = canModify,
-                isOffline = isOffline
+                isOffline = isOffline || watchersState.areWatchersLoading
             )
 
             if (index < watchersState.watchers.lastIndex) {

--- a/feature/workitem/ui/src/commonMain/kotlin/com/grappim/taigamobile/feature/workitem/ui/widgets/tags/WorkItemTagsWidget.kt
+++ b/feature/workitem/ui/src/commonMain/kotlin/com/grappim/taigamobile/feature/workitem/ui/widgets/tags/WorkItemTagsWidget.kt
@@ -55,7 +55,7 @@ fun WorkItemTagsWidget(
                         onTagRemoveClick(tag)
                     },
                     canModify = canModify,
-                    isOffline = isOffline
+                    isOffline = isOffline || tagsState.areTagsLoading
                 )
             }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -144,6 +144,7 @@ jetbrains-compose-material3-adaptive-navigation-suite = { module = "org.jetbrain
 jetbrains-compose-material3-adaptive = { module = "org.jetbrains.compose.material3.adaptive:adaptive", version.ref = "jetbrainsComposeMaterial3Adaptive" }
 jetbrains-lifecycle-runtime-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "jetbrainsAndroidxLifecycle" }
 jetbrains-lifecycle-viewmodel-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "jetbrainsAndroidxLifecycle" }
+jetbrains-lifecycle-viewmodel-savedstate = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-savedstate", version.ref = "jetbrainsAndroidxLifecycle" }
 jetbrains-androidx-savedstate = { module = "org.jetbrains.androidx.savedstate:savedstate", version.ref = "jetbrainsSavedState" }
 jetbrains-compose-icons = { module = "org.jetbrains.compose.material:material-icons-core", version.ref = "jetbrainsComposeIcons" }
 jetbrains-compose-icons-extended = { module = "org.jetbrains.compose.material:material-icons-extended", version.ref = "jetbrainsComposeIcons" }

--- a/utils/ui/src/commonMain/kotlin/com/grappim/taigamobile/utils/ui/RestorableState.kt
+++ b/utils/ui/src/commonMain/kotlin/com/grappim/taigamobile/utils/ui/RestorableState.kt
@@ -1,0 +1,17 @@
+package com.grappim.taigamobile.utils.ui
+
+import androidx.lifecycle.SavedStateHandle
+
+/**
+ * Persists individual UI-state fields to [savedStateHandle] so they survive process death.
+ * [restore] seeds a ViewModel's initial state; [save] is called from that field's setter
+ * alongside the usual `_state.update { }`. Only supports the types [SavedStateHandle] itself
+ * natively stores (String, Int, Boolean, etc.) — not arbitrary objects.
+ */
+class RestorableState(private val savedStateHandle: SavedStateHandle) {
+    fun <T> restore(key: String, default: T): T = savedStateHandle[key] ?: default
+
+    fun <T> save(key: String, value: T) {
+        savedStateHandle[key] = value
+    }
+}

--- a/utils/ui/src/commonTest/kotlin/com/grappim/taigamobile/utils/ui/RestorableStateTest.kt
+++ b/utils/ui/src/commonTest/kotlin/com/grappim/taigamobile/utils/ui/RestorableStateTest.kt
@@ -1,0 +1,35 @@
+package com.grappim.taigamobile.utils.ui
+
+import androidx.lifecycle.SavedStateHandle
+import com.grappim.taigamobile.testing.utils.getRandomString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RestorableStateTest {
+
+    @Test
+    fun `restore - no prior value - returns the default`() {
+        val restorableState = RestorableState(SavedStateHandle())
+
+        assertEquals("default", restorableState.restore("key", "default"))
+    }
+
+    @Test
+    fun `restore - prior value present - returns it instead of the default`() {
+        val restored = getRandomString()
+        val restorableState = RestorableState(SavedStateHandle(mapOf("key" to restored)))
+
+        assertEquals(restored, restorableState.restore("key", "default"))
+    }
+
+    @Test
+    fun `save - writes the value into the SavedStateHandle under the given key`() {
+        val savedStateHandle = SavedStateHandle()
+        val restorableState = RestorableState(savedStateHandle)
+        val value = getRandomString()
+
+        restorableState.save("key", value)
+
+        assertEquals(value, savedStateHandle.get<String>("key"))
+    }
+}


### PR DESCRIPTION
## Summary
- Adds the checklist/implementation-plan pair for the ViewModel lifecycle & error-handling hardening initiative, sourced from an "Android Lead" newsletter article review.
- Each checklist step will land as its own commit on this branch as it's worked.

## Test plan
- [ ] Step 1: CoroutineExceptionHandler on ApplicationScope
- [ ] Step 2: gated — process-death UI-state restoration scope decision
- [ ] Step 3: investigate constructor-injected initialState (OTOS)
- [ ] Step 4: gate watch/unwatch button on areWatchersLoading
- [ ] Step 5: investigate redundant init-time re-fetches
- [ ] Step 6: investigate whether the watch/unwatch race generalizes
- [ ] Step 7: investigate UiState-leak and derived-property convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)