### PR TITLE
chore: add generateProjectDependencyGraph task

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,9 @@ and stop.
 ./gradlew :composeApp:compileKotlinIosArm64 --rerun-tasks            # iOS device
 # Android equivalent (also forces Koin compiler logs):
 ./gradlew :androidApp:compileFdroidDebugKotlin --rerun-tasks
+
+# Render the full module dependency graph (requires graphviz: apt/brew install graphviz)
+./gradlew generateProjectDependencyGraph   # → build/reports/dependency-graph/project.png
 ```
 
 ## Architecture

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -240,3 +240,5 @@ val syncIosVersion by tasks.registering {
 project(":composeApp").tasks.matching { it.name.startsWith("assembleTaigaMobileNova") }.configureEach {
     dependsOn(syncIosVersion)
 }
+
+apply(from = "gradle/projectDependencyGraph.gradle")

--- a/gradle/projectDependencyGraph.gradle
+++ b/gradle/projectDependencyGraph.gradle
@@ -1,0 +1,118 @@
+// Adapted from HedvigInsurance's gradle/projectDependencyGraph.gradle, itself adapted from
+// https://github.com/chrisbanes/tivi/blob/main/gradle/dependencyGraph.gradle
+
+def font = "Helvetica"
+
+task generateProjectDependencyGraph {
+    notCompatibleWithConfigurationCache("Uses project inside `doLast`.")
+    doLast {
+        def dot = new File(rootProject.buildDir, 'reports/dependency-graph/project.dot')
+        dot.parentFile.mkdirs()
+        dot.delete()
+
+        dot << 'digraph {\n'
+        dot << "  graph [label=\"${rootProject.name}\\n \",labelloc=t,fontsize=30,ranksep=1.4,fontname=\"$font\"];\n"
+        dot << "  node [style=filled, fillcolor=\"#bbbbbb\", fontname=\"$font\"];\n"
+        dot << "  edge [fontname = \"$font\"];"
+        dot << '  rankdir=TB;\n'
+
+        def rootProjects = []
+        def queue = [rootProject]
+        while (!queue.isEmpty()) {
+            def project = queue.remove(0)
+            rootProjects.add(project)
+            queue.addAll(project.childProjects.values())
+        }
+
+        def projects = new LinkedHashSet<Project>()
+        def dependencies = new LinkedHashMap<Tuple2<Project, Project>, List<String>>()
+        def multiplatformProjects = []
+        def androidAppProjects = []
+        def kotlinJvmProjects = []
+
+        queue = [rootProject]
+        while (!queue.isEmpty()) {
+            def project = queue.remove(0)
+            queue.addAll(project.childProjects.values())
+
+            // Checked in this order: a KMP module (composeApp, feature/core/utils/*) can also carry
+            // an Android target via com.android.kotlin.multiplatform.library, so the KMP check must
+            // win first or every KMP module would misreport as a plain Android module.
+            if (project.plugins.hasPlugin('org.jetbrains.kotlin.multiplatform')) {
+                multiplatformProjects.add(project)
+            } else if (project.plugins.hasPlugin('com.android.application')) {
+                androidAppProjects.add(project)
+            } else if (project.plugins.hasPlugin('org.jetbrains.kotlin.jvm')) {
+                // tools/seed, tools/utils — plain kotlin("jvm") modules, no KMP/Android target.
+                kotlinJvmProjects.add(project)
+            }
+
+            project.configurations.all { config ->
+                config.dependencies
+                        .withType(ProjectDependency)
+                        .collect { rootProject.findProject(it.path) }
+                        .findAll { it != null }
+                        .each { dependency ->
+                            projects.add(project)
+                            projects.add(dependency)
+                            rootProjects.remove(dependency)
+
+                            def graphKey = new Tuple2<Project, Project>(project, dependency)
+                            def traits = dependencies.computeIfAbsent(graphKey) { new ArrayList<String>() }
+
+                            def configLowerCaseName = config.name.toLowerCase()
+                            if (configLowerCaseName.endsWith('implementation') || configLowerCaseName.endsWith('lintchecks')) {
+                                traits.add('style=dotted')
+                            }
+                        }
+            }
+        }
+
+        projects = projects.sort { it.path }
+
+        dot << '\n  # Projects\n\n'
+        for (project in projects) {
+            def traits = []
+
+            if (rootProjects.contains(project)) {
+                continue
+            }
+
+            if (multiplatformProjects.contains(project)) {
+                traits.add('fillcolor="#ffd2b3"')
+            } else if (androidAppProjects.contains(project)) {
+                traits.add('fillcolor="#baffc9"')
+            } else if (kotlinJvmProjects.contains(project)) {
+                traits.add('fillcolor="#ffb3ba"')
+            } else {
+                traits.add('fillcolor="#eeeeee"')
+            }
+
+            dot << "  \"${project.path}\" [${traits.join(", ")}];\n"
+        }
+
+        dot << '\n  # Dependencies\n\n'
+        dependencies.forEach { key, traits ->
+            def isEmptyPath = key.first.path == ':'
+            def isPointingToSelf = key.first.path == key.second.path
+            if (!isEmptyPath && !isPointingToSelf) {
+                dot << "  \"${key.first.path}\" -> \"${key.second.path}\""
+                if (!traits.isEmpty()) {
+                    dot << " [${traits.join(", ")}]"
+                }
+                dot << '\n'
+            }
+        }
+
+        dot << '}\n'
+
+        def pngPath = "${rootProject.buildDir}/reports/dependency-graph/project.png"
+        def p = "dot -Tpng -o ${pngPath} ${dot}".execute()
+        p.waitFor()
+        if (p.exitValue() != 0) {
+            throw new RuntimeException(p.errorStream.text)
+        }
+
+        println("Project module dependency graph created at ${pngPath}")
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `./gradlew generateProjectDependencyGraph` — renders the full ~80-module dependency graph to a Graphviz PNG (`build/reports/dependency-graph/project.png`), colored by module kind (KMP orange, Android app green, plain Kotlin/JVM pink).
- Adapted from HedvigInsurance's `gradle/projectDependencyGraph.gradle` (found scouting its `CLAUDE.md`, tracked in `agentic-grappim/investigations/reference-app-scouting.md`), itself originally from `chrisbanes/tivi`. Re-pointed the module-kind detection at this repo's actual plugin ids (`org.jetbrains.kotlin.multiplatform`, `com.android.application`, `org.jetbrains.kotlin.jvm` for `tools/*`) instead of Hedvig's.
- Output goes to `build/` (already gitignored), not a committed image — nothing to keep in sync.

## Test plan
- [x] `./gradlew generateProjectDependencyGraph` — succeeds, produces a 23336×2897 PNG and a well-formed `.dot` with correct per-module coloring (spot-checked `:androidApp` green, `:composeApp`/`:core:*`/`:testing`/`:uikit` orange)
- [x] `.github/scripts/check-guardrails.sh HEAD~1..HEAD` — nothing tripped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EkQqhy78cPsTxgKi98UGaD