### PR TITLE
chore(deps): update composeRules to v0.6.6

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,7 +30,7 @@ ktlint = "14.2.0"
 # https://github.com/Kotlin/kotlinx-kover/releases
 kover = "0.9.9"
 # https://github.com/mrmans0n/compose-rules/releases
-composeRules = "0.6.4"
+composeRules = "0.6.6"
 
 # https://developer.android.com/reference/tools/gradle-api
 agp = "9.3.1"


### PR DESCRIPTION
## Summary
- Reapplies Renovate's #376 (`composeRules` 0.6.4 → 0.6.6) as an authored commit carrying a `Gate-change:` trailer, since a bot commit can't and this key trips `guardrails.yml`.
- No other changes.

## Test plan
- [x] `.github/scripts/check-guardrails.sh HEAD~1..HEAD` passes locally
- [ ] CI green

Closes #376.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWcaUprxrKMKfe5PwjCi3v