### PR TITLE
fix(deps): update agp to v9.4.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,7 @@ kover = "0.9.9"
 composeRules = "0.6.4"
 
 # https://developer.android.com/reference/tools/gradle-api
-agp = "9.3.1"
+agp = "9.4.0"
 # https://github.com/google/desugar_jdk_libs/blob/master/CHANGELOG.md
 androidDesugarJdkLibs = "2.1.5"
 


### PR DESCRIPTION
## Summary
- Reapplies Renovate's #368 (`agp` 9.3.1 → 9.4.0) as an authored commit carrying a `Gate-change:` trailer, since a bot commit can't and this key trips `guardrails.yml`.
- No other changes.

## Test plan
- [x] `.github/scripts/check-guardrails.sh HEAD~1..HEAD` passes locally
- [ ] CI green

Closes #368.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWcaUprxrKMKfe5PwjCi3v