### PR TITLE
chore(deps): update actions/setup-java action to v6

### DIFF
--- a/.github/actions/android-setup-composite-action/action.yml
+++ b/.github/actions/android-setup-composite-action/action.yml
@@ -6,7 +6,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Java 21
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v6
       with:
         java-version: '21'
         distribution: 'temurin'


### PR DESCRIPTION
## Summary
- Reapplies Renovate's #373 (`actions/setup-java` v5 → v6 in the shared Android setup composite action) as an authored commit carrying a `Gate-change:` trailer, since a bot commit can't and touching `.github/` trips `guardrails.yml`.
- No other changes.

## Test plan
- [x] `.github/scripts/check-guardrails.sh HEAD~1..HEAD` passes locally
- [ ] CI green

Closes #373.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWcaUprxrKMKfe5PwjCi3v