### PR TITLE
fix(nav): stop drawer section switches from growing the back stack

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -517,6 +517,14 @@ on releases, so diffing against it re-checks the entire dev-vs-master backlog in
 release branch's own commits. See `docs/revisit.md` #47 for the equivalent, still-open gap on the
 `push`-triggered run that fires on `master` right after the merge.
 
+**Never write a bare `#N` to reference a `docs/revisit.md`/archive entry number in a PR/issue
+description, comment, or commit message.** GitHub autolinks any `#<digits>` rendered through its
+web UI (PR/issue bodies and comments, and file content rendered from the repo) to that repo's own
+issue/PR `#N` — unrelated to what `N` actually means here — the moment an issue or PR with that
+number exists. "tracked as revisit #51" in a PR description silently became a link to PR #51.
+Write `revisit.md entry 51` / `revisit #51 (docs/revisit.md)`, or wrap it in backticks (`` `#51` ``,
+which suppresses GitHub's autolink), instead of a bare `#51`.
+
 ## Skills & Agents
 
 `.claude/agents/` in this repo holds only the project-specific agents: **testing** and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,15 @@ every section and lands on `key` alone (login/logout); `replaceCurrent(key)` swa
 top entry instead of pushing (a "this screen is done, hand off to the next one" transition, e.g. a
 wiki create-page screen handing off to the page it just created).
 
+**Switching top-level sections replaces the active slot in `topLevelStack`, it does not push.**
+`goToTopLevel()` (the branch `navigate()` takes for any top-level key that isn't the current one)
+writes the new key into `topLevelStack`'s existing slot rather than appending — so drawer-tap chains
+(Epics → Issues → Kanban) never grow the stack past whatever depth it already had (size 1 outside
+`resetTo()`), and `goBack()`/`canGoBack()` treat any section's root as unhandled — falling through to
+the system/exit — instead of walking back through previously-visited sections. Fixed 2026-09-07
+(was `removeAll` + `add`, which pushed and made back cascade through every section visited that
+session); see `docs/archive/revisit-resolved.md`#51 for the full mechanism and fix.
+
 **`NavigationIconConfig.Back()` with no `onBackClick` does not call the screen's own `goBack`
 param** — `TaigaTopAppBar.kt`'s `NavigationIcon` falls back to a `defaultGoBack` wired centrally in
 `MainScreen.kt` instead. Any screen whose `goBack` lambda does something beyond `navigator.goBack()`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,17 @@ the system/exit — instead of walking back through previously-visited sections.
 (was `removeAll` + `add`, which pushed and made back cascade through every section visited that
 session); see `docs/archive/revisit-resolved.md`#51 for the full mechanism and fix.
 
+**Any screen whose back handling assumes `goBack()` pops past its own top-level boundary broke
+when the above landed.** `ProjectSelectorScreen`'s login-abandon path is the one confirmed case:
+its `NavigationBackHandler`/back-arrow (`isBackEnabled = state.isFromLogin`) used to rely on
+`goBack()` popping `topLevelStack` from `[Login, ProjectSelector]` back to `[Login]` — under the
+replace-not-push fix that pop has nothing to do, so `goBack()` silently no-ops and the back
+gesture does nothing. Fixed 2026-09-08 by having `MainNavHost.kt`'s `ProjectSelectorScreen` call
+site wire `goBack` to `navigator.resetTo(LoginNavDestination)` instead — see
+`docs/issues/2026-09-08-project-selector-back-after-login-does-nothing.md`. Any other screen that
+is simultaneously a top-level key *and* expects back to escape past its own section (not just
+pop its own sub-stack) needs the same treatment, not plain `navigator.goBack()`.
+
 **`NavigationIconConfig.Back()` with no `onBackClick` does not call the screen's own `goBack`
 param** — `TaigaTopAppBar.kt`'s `NavigationIcon` falls back to a `defaultGoBack` wired centrally in
 `MainScreen.kt` instead. Any screen whose `goBack` lambda does something beyond `navigator.goBack()`

--- a/composeApp/src/commonMain/kotlin/com/grappim/taigamobile/main/MainNavHost.kt
+++ b/composeApp/src/commonMain/kotlin/com/grappim/taigamobile/main/MainNavHost.kt
@@ -155,8 +155,12 @@ fun MainNavHost(
             }
             ProjectSelectorScreen(
                 route = route,
+                // only ever invoked on the isFromLogin path (see ProjectSelectorScreen's own
+                // back handling) — resetTo() lands back on Login. navigator.goBack() has nowhere
+                // to pop to here since ProjectSelector replaces Login's topLevelStack slot rather
+                // than pushing onto it.
                 goBack = {
-                    navigator.goBack()
+                    navigator.resetTo(LoginNavDestination)
                 },
                 onProjectSelect = {
                     navigator.navigateToDashboardAsTopDestination()

--- a/core/navigation/src/commonMain/kotlin/com/grappim/taigamobile/core/navigation/Navigator.kt
+++ b/core/navigation/src/commonMain/kotlin/com/grappim/taigamobile/core/navigation/Navigator.kt
@@ -89,15 +89,15 @@ class Navigator(val state: NavigationState) {
         }
     }
 
+    /**
+     * Switches section by replacing the current entry in [NavigationState.topLevelStack] rather
+     * than pushing, so switching sections never grows the stack — [goBack] at any section's root
+     * is then unhandled (falls through to the system/exit) instead of walking back through
+     * previously-visited sections.
+     */
     private fun goToTopLevel(key: NavKey) {
-        state.topLevelStack.apply {
-            if (key::class == state.startKey::class) {
-                clear()
-            } else {
-                removeAll { it::class == key::class }
-            }
-            add(key)
-        }
+        val topLevelStack = state.topLevelStack
+        topLevelStack[topLevelStack.lastIndex] = key
         // carry the fresh payload (if any) into the target section's own sub-stack root too —
         // toEntries() renders from subStacks, not topLevelStack, so this is what the screen
         // actually sees.

--- a/core/navigation/src/commonTest/kotlin/com/grappim/taigamobile/core/navigation/NavigatorTest.kt
+++ b/core/navigation/src/commonTest/kotlin/com/grappim/taigamobile/core/navigation/NavigatorTest.kt
@@ -70,18 +70,19 @@ class NavigatorTest {
     }
 
     @Test
-    fun `navigate to another top level key switches section and keeps each sub stack`() {
+    fun `navigate to another top level key replaces the section and keeps each sub stack`() {
         val navigator = navigator()
         navigator.navigate(DetailRoute(1))
 
         navigator.navigate(SettingsRoute)
 
-        assertEquals(listOf(HomeRoute, SettingsRoute), navigator.state.topLevelStack.toList())
+        assertEquals(listOf(SettingsRoute), navigator.state.topLevelStack.toList())
         assertEquals(listOf(SettingsRoute), navigator.state.currentSubStack.toList())
 
         navigator.navigate(HomeRoute)
         // back on Home, its sub stack is untouched — the re-tap reset only applies to the section
         // that is already current, and Home was not
+        assertEquals(listOf(HomeRoute), navigator.state.topLevelStack.toList())
         assertEquals(
             listOf(HomeRoute, DetailRoute(1)),
             navigator.state.currentSubStack.toList()
@@ -89,28 +90,17 @@ class NavigatorTest {
     }
 
     @Test
-    fun `navigate to the start key clears the top level stack`() {
+    fun `navigate between top level keys never grows the top level stack`() {
         val navigator = navigator()
         navigator.navigate(SettingsRoute)
         navigator.navigate(AboutRoute)
+        navigator.navigate(SettingsRoute)
+
+        assertEquals(listOf(SettingsRoute), navigator.state.topLevelStack.toList())
 
         navigator.navigate(HomeRoute)
 
         assertEquals(listOf(HomeRoute), navigator.state.topLevelStack.toList())
-    }
-
-    @Test
-    fun `navigate to a top level key already in the stack moves it to the top`() {
-        val navigator = navigator()
-        navigator.navigate(SettingsRoute)
-        navigator.navigate(AboutRoute)
-
-        navigator.navigate(SettingsRoute)
-
-        assertEquals(
-            listOf(HomeRoute, AboutRoute, SettingsRoute),
-            navigator.state.topLevelStack.toList()
-        )
     }
 
     @Test
@@ -123,19 +113,19 @@ class NavigatorTest {
 
         assertTrue(handled)
         assertEquals(listOf(SettingsRoute), navigator.state.currentSubStack.toList())
-        assertEquals(listOf(HomeRoute, SettingsRoute), navigator.state.topLevelStack.toList())
+        assertEquals(listOf(SettingsRoute), navigator.state.topLevelStack.toList())
     }
 
     @Test
-    fun `goBack at a sub stack root pops the top level stack`() {
+    fun `goBack at a top level section root is not handled - switching sections doesn't grow the back stack`() {
         val navigator = navigator()
         navigator.navigate(SettingsRoute)
 
         val handled = navigator.goBack()
 
-        assertTrue(handled)
-        assertEquals(listOf(HomeRoute), navigator.state.topLevelStack.toList())
-        assertEquals(HomeRoute, navigator.state.currentKey)
+        assertFalse(handled)
+        assertEquals(listOf(SettingsRoute), navigator.state.topLevelStack.toList())
+        assertEquals(SettingsRoute, navigator.state.currentKey)
     }
 
     @Test
@@ -149,7 +139,7 @@ class NavigatorTest {
     }
 
     @Test
-    fun `canGoBack is false only at the start destination`() {
+    fun `canGoBack is false at any top level section root, true only inside a sub stack`() {
         val navigator = navigator()
         assertFalse(navigator.canGoBack())
 
@@ -160,7 +150,7 @@ class NavigatorTest {
         assertFalse(navigator.canGoBack())
 
         navigator.navigate(SettingsRoute)
-        assertTrue(navigator.canGoBack())
+        assertFalse(navigator.canGoBack())
     }
 
     @Test
@@ -172,7 +162,7 @@ class NavigatorTest {
         navigator.navigate(PayloadTopLevelRoute(flag = true))
 
         assertEquals(
-            listOf(HomeRoute, PayloadTopLevelRoute(flag = true)),
+            listOf(PayloadTopLevelRoute(flag = true)),
             navigator.state.topLevelStack.toList()
         )
         assertEquals(PayloadTopLevelRoute(flag = true), navigator.state.currentKey)
@@ -183,7 +173,7 @@ class NavigatorTest {
         navigator.navigate(PayloadTopLevelRoute(flag = false))
 
         assertEquals(
-            listOf(HomeRoute, SettingsRoute, PayloadTopLevelRoute(flag = false)),
+            listOf(PayloadTopLevelRoute(flag = false)),
             navigator.state.topLevelStack.toList()
         )
     }

--- a/docs/archive/revisit-resolved.md
+++ b/docs/archive/revisit-resolved.md
@@ -54,6 +54,7 @@ Still-open items live in [docs/revisit.md](../revisit.md); nothing here needs a 
 | 43 | [Issues list has no dividers between rows on desktop](#43-issues-list-has-no-dividers-between-rows-on-desktop) | ➡️ moved to tablet checklist 2026-08-22 |
 | 44 | [Desktop has no refresh affordance for pull-to-refresh screens](#44-desktop-has-no-refresh-affordance-for-pull-to-refresh-screens) | ➡️ moved to tablet checklist 2026-08-22 |
 | 49 | [Kanban fetches `filters_data` twice on load](#49-kanban-fetches-filters_data-twice-on-load) | ✅ resolved 2026-09-07 |
+| 51 | [Switching drawer sections is recorded on the back stack, so back cascades through prior sections](#51-switching-drawer-sections-is-recorded-on-the-back-stack-so-back-cascades-through-prior-sections) | ✅ resolved 2026-09-07 |
 
 ---
 
@@ -2079,4 +2080,66 @@ Verified with `./gradlew jvmTest ktlintCheck` (full suite, clean), `./gradlew ko
 :koverVerify` (floor still met), and a repo-wide grep confirming no remaining Kanban-side reference to
 `filtersError`/`isFiltersLoading`/`onRetryFilters`/`loadFiltersData` (Scrum/Epics/Issues's own,
 legitimate copies are untouched).
+
+## 51. Switching drawer sections is recorded on the back stack, so back cascades through prior sections
+
+**Where:** `core/navigation/src/commonMain/kotlin/com/grappim/taigamobile/core/navigation/Navigator.kt`
+— `goToTopLevel()` (lines 92-107) and `goBack()` (lines 35-47);
+`core/navigation/src/commonMain/kotlin/com/grappim/taigamobile/core/navigation/NavigationState.kt:28-33`
+(`topLevelStack: NavBackStack<NavKey>`, `currentTopLevelKey = topLevelStack.last()`).
+
+**What:** reported by gregory (2026-09-07): navigate Epics → Issues via the drawer, then press back —
+lands on Epics instead of wherever was open before Epics (or exiting the app), which reads as
+unexpected. Traced to the mechanism: `topLevelStack` is a real stack, not a "currently selected
+section" pointer. `goToTopLevel(key)` (`Navigator.kt:92-99`) removes any existing entry for that
+section's class then `add(key)s` it — so switching sections *pushes*, it doesn't replace. `goBack()`
+(`Navigator.kt:35-41`) pops `topLevelStack` whenever the current screen is itself the top of its
+section's sub-stack, so a chain of drawer taps (Epics → Issues → Kanban → …) builds a stack of
+sections that back walks through one at a time, most-recent-first, before ever reaching whatever was
+open before the first drawer tap. `NavigationState.kt:20-21`'s own doc comment confirms this is by
+design ("`topLevelStack` records which drawer section is active"), not an oversight — but it's a
+different UX model than the typical drawer/bottom-nav pattern (Android's own bottom-nav guidance,
+most drawer apps) where switching top-level destinations does *not* grow the back stack and back
+either returns to the single previous screen or exits.
+
+**Consequence:** every drawer navigation the user makes silently extends how many back-presses it
+takes to leave the app, and the "previous section" back lands on is whichever was tapped most
+recently — not necessarily the one the user thinks of as "before this."
+
+**Why deferred:** UX behavior change to a core, deliberately-designed piece of shared navigation
+infrastructure (`Navigator`/`NavigationState` back all top-level nav — drawer, rail, permanent drawer
+across phone/tablet/desktop per the tablet-form-factor-support work), not something to redesign as a
+side note. Needs a decision on the intended model, not just a code change.
+
+**Fix, if wanted:** the conventional alternative is what `resetSubStackTo()` already does for
+re-tapping the *active* section (`Navigator.kt:109-116`, `topLevelStack[lastIndex] = key` — replace,
+not push) — applying the same replace-not-push shape to `goToTopLevel()` would make switching
+sections never grow `topLevelStack` past whatever depth it already had, so back would skip past
+previously-visited sections entirely and go straight to wherever the user was before entering the
+drawer flow (or exit, if that was the start destination). Confirm with gregory this is the wanted
+model before changing it — the current design may be intentional to let users "walk back" through
+their drawer navigation history, which is also a defensible choice some apps make deliberately.
+
+**Fix (2026-09-07):** gregory confirmed the replace-not-push model. Changed `goToTopLevel()`
+(`Navigator.kt`) to do exactly that — `topLevelStack[topLevelStack.lastIndex] = key` instead of the
+old `removeAll { it::class == key::class }` + `add(key)`, mirroring `resetSubStackTo()`'s shape. This
+also made the `key::class == state.startKey::class -> clear()` special case unnecessary and it was
+removed: since every `goToTopLevel()` call now replaces rather than grows the stack, there's no
+accumulated history to clear regardless of which section is the target. `goBack()`/`canGoBack()`
+(`Navigator.kt:35-50`) were left untouched — their existing `topLevelStack.size > 1` checks now simply
+never trigger post-fix (the stack is invariant at size 1 outside of `resetTo()`), which is the correct
+behavior with no code change needed there: back at any section's root now falls through to the
+system/exit instead of walking through previously-visited sections. Confirmed no other file reads
+`topLevelStack`/`goToTopLevel`/`currentTopLevelKey` (grepped repo-wide), so this was a self-contained
+change. Updated `NavigatorTest.kt`'s six affected tests (renamed
+`navigate to another top level key switches section...` → `...replaces the section...`; replaced
+`navigate to the start key clears the top level stack` / `navigate to a top level key already in the
+stack moves it to the top` with a single `navigate between top level keys never grows the top level
+stack`; rewrote `goBack at a sub stack root pops the top level stack` → `goBack at a top level section
+root is not handled...`; updated `canGoBack is false only at the start destination` →
+`...at any top level section root, true only inside a sub stack`; fixed the payload-identity test's
+expected stacks) to assert the new invariant. Verified with `./gradlew :core:navigation:jvmTest`
+(12/12 green), full `./gradlew jvmTest` (all green, no cross-module fallout), and
+`./gradlew :core:navigation:ktlintCommonMainSourceSetCheck :core:navigation:ktlintCommonTestSourceSetCheck`
+(clean).
 

--- a/docs/archive/revisit-resolved.md
+++ b/docs/archive/revisit-resolved.md
@@ -2130,8 +2130,13 @@ accumulated history to clear regardless of which section is the target. `goBack(
 never trigger post-fix (the stack is invariant at size 1 outside of `resetTo()`), which is the correct
 behavior with no code change needed there: back at any section's root now falls through to the
 system/exit instead of walking through previously-visited sections. Confirmed no other file reads
-`topLevelStack`/`goToTopLevel`/`currentTopLevelKey` (grepped repo-wide), so this was a self-contained
-change. Updated `NavigatorTest.kt`'s six affected tests (renamed
+`topLevelStack`/`goToTopLevel`/`currentTopLevelKey` (grepped repo-wide) — **this grep was
+insufficient**: it only found direct readers of the changed state, not a caller depending on
+`goBack()`'s postcondition built on top of it. `ProjectSelectorScreen`'s login-abandon back
+handling relied on `goBack()` actually popping `topLevelStack` past `Login`, without reading any
+of the three symbols directly — see
+`docs/issues/2026-09-08-project-selector-back-after-login-does-nothing.md` for the regression this
+caused and its fix. Updated `NavigatorTest.kt`'s six affected tests (renamed
 `navigate to another top level key switches section...` → `...replaces the section...`; replaced
 `navigate to the start key clears the top level stack` / `navigate to a top level key already in the
 stack moves it to the top` with a single `navigate between top level keys never grows the top level

--- a/docs/issues/2026-09-08-project-selector-back-after-login-does-nothing.md
+++ b/docs/issues/2026-09-08-project-selector-back-after-login-does-nothing.md
@@ -1,0 +1,220 @@
+# 2026-09-08 — Back does nothing on Select Project screen right after login
+
+**Status:** Done
+**Link:** reported by gregory in conversation (no GitHub issue)   **Updated:** 2026-09-08
+
+## Report
+
+gregory (2026-09-08): "when we log in, we go to select project screen, and here we cannot go
+back neither back gesture nor back button do not work. When I am logged in and I go to Select
+Project screen the back behavior works, i.e. we leave the app."
+
+Two states of the same screen, different back behavior:
+
+| Path to Select Project | Back gesture / back button |
+|---|---|
+| Fresh login → Select Project | Nothing happens (no navigation, no exit) |
+| Already logged in, switch to Select Project via drawer | App exits, as expected |
+
+Not stated: platform (Android is the only one with a hardware/gesture "back button" in the
+literal sense reported, so this investigation assumes Android; the same code path is shared by
+desktop/iOS but they have no back gesture to test this way) and app version. Not needed to find
+the cause — the difference between the two paths only exists in one place in the code (see
+below), and that place changed very recently.
+
+## Findings
+
+- `ProjectSelectorNavDestination` is a **top-level key** (`MainAppState.kt:36`, in
+  `TOP_LEVEL_KEYS`), not a leaf screen — it gets its own slot in `Navigator`'s `topLevelStack`.
+- `ProjectSelectorScreen.kt:100-107` installs its own `NavigationBackHandler`:
+  ```kotlin
+  NavigationBackHandler(
+      state = rememberNavigationEventState(NavigationEventInfo.None),
+      isBackEnabled = state.isFromLogin,
+      onBackCompleted = {
+          state.onGoingBackAfterLogIn()
+          goBack()
+      }
+  )
+  ```
+  `isBackEnabled = state.isFromLogin` — enabled only on the fresh-login path, disabled when the
+  screen is reached any other way (e.g. the drawer). `goBack` is wired in
+  `MainNavHost.kt:158-160` to plain `navigator.goBack()`.
+- `state.onGoingBackAfterLogIn()` → `ProjectSelectorViewModel.onGoingBackAfterLogIn()`
+  (`ProjectSelectorViewModel.kt:59-63`) calls `dataCleaner.cleanOnGoingBackAfterLogin()` — this
+  is a deliberate "abandon the fresh login" feature: back out before picking a project, and the
+  session that login just created gets wiped.
+- `LoginScreen`'s `onLoginSuccess` (`MainNavHost.kt:144`) calls
+  `navigator.navigateToProjectSelector(isFromLogin = true)`. `MainAppState.kt:34-48`'s
+  `TOP_LEVEL_KEYS` includes `LoginNavDestination` itself, and `rememberMainAppState()`
+  (`MainAppState.kt:53`) seeds `startKey = LoginNavDestination` — so `topLevelStack` starts as
+  `[Login]`.
+- **Before PR #392** (`fix/nav-drawer-back-stack-cascade`, 2026-09-07): `Navigator.goToTopLevel()`
+  pushed onto `topLevelStack` (`removeAll { it::class == key::class }` then `add(key)`).
+  Login → ProjectSelector(isFromLogin=true) therefore produced `topLevelStack = [Login,
+  ProjectSelector]` (size 2). Pressing back then hit `Navigator.goBack()`'s
+  `state.topLevelStack.size > 1` branch, which was **true** — it popped back to `Login`. That
+  pop is exactly what `onGoingBackAfterLogIn()`'s session-wipe was designed to precede: "back out
+  of project selection, land back on the Login screen, with the half-finished session cleaned
+  up."
+- **After PR #392**: `goToTopLevel()` now *replaces* the top of `topLevelStack` instead of
+  pushing (`Navigator.kt:96-107`, current). Login → ProjectSelector(isFromLogin=true) now
+  produces `topLevelStack = [ProjectSelector]` (size 1). `Navigator.goBack()`'s
+  `state.topLevelStack.size > 1` check is now **false** — `goBack()` returns `false` (unhandled)
+  and does nothing.
+- The `ProjectSelectorScreen` `NavigationBackHandler` does not look at `goBack()`'s return value
+  — it calls `state.onGoingBackAfterLogIn()` and `goBack()` unconditionally inside
+  `onBackCompleted`. Because `isBackEnabled = true` on this path, the handler still **consumes**
+  the back gesture/button (per `androidx.navigationevent`'s docs quoted in
+  `MainScreen.kt:176-178`, an enabled handler wins over letting the event fall through), so no
+  other handler or the system gets a chance to act on it — the event is swallowed and nothing
+  visible happens. This matches the report exactly: not "the wrong thing happens," but "nothing
+  happens."
+  - Aside: `onGoingBackAfterLogIn()`'s side effect (wiping the fresh session) *does* still fire on
+    every back press on this path even though nothing else happens, since it runs before the
+    now-inert `goBack()` call — not confirmed by a live run, but follows directly from the code
+    order in `ProjectSelectorScreen.kt:103-106`. Not part of the reported symptom, but worth
+    knowing: every "broken" back press on this screen is quietly deleting the session anyway.
+  - Not confirmed live (no emulator run in this investigation) — this trace is static, from
+    reading `Navigator.kt`, `ProjectSelectorScreen.kt`, `MainNavHost.kt`, and `MainAppState.kt`
+    together. Treat the mechanism as strong inference, not an observed stack trace.
+- On the **drawer path** (`isFromLogin = false`): the local `NavigationBackHandler` is disabled,
+  so it doesn't intercept. No other handler in the tree calls `navigator.goBack()` for a
+  top-level screen (`MainScreen.kt`'s own `NavigationBackHandler`, lines 188-196, only closes the
+  drawer and is unrelated). With nothing consuming the event, the platform's own back handling
+  takes over — which for a single-activity Compose app with no consumer is exiting. This is the
+  behavior the reporter confirmed as correct, and it is unaffected by PR #392 either way (it
+  never depended on `topLevelStack` size).
+
+## Root cause
+
+PR #392 (`fix/nav-drawer-back-stack-cascade`) changed `Navigator.goToTopLevel()` from
+push-onto-`topLevelStack` to replace-the-top-of-`topLevelStack`, to fix drawer-section back
+cascading (revisit #51). That fix was correct for the drawer case it targeted, but
+`ProjectSelectorScreen`'s login-abandon feature (`isBackEnabled = state.isFromLogin`,
+`ProjectSelectorScreen.kt:100-107`) depended on the *old* push behavior: it relies on
+`navigator.goBack()` actually popping `topLevelStack` from `[Login, ProjectSelector]` back down
+to `[Login]`. Under the new replace-only invariant, `topLevelStack` never grows past size 1
+outside `resetTo()`, so that pop never had anything to do — `goBack()` now always returns `false`
+here, and the screen's own `NavigationBackHandler` swallows the gesture regardless, since it
+doesn't check the return value.
+
+This is a real regression PR #392 introduced, not a pre-existing bug independently rediscovered
+— `docs/archive/revisit-resolved.md`#51's own `Fix` note stated "no other file reads
+`topLevelStack`/`goToTopLevel`/`currentTopLevelKey`," which was true by grep but missed that
+`ProjectSelectorScreen`'s `isBackEnabled`/`goBack()` combination depends on `goBack()`'s *return
+value having an effect*, not on reading the stack directly — the grep for direct readers didn't
+catch a caller relying on the postcondition of `goToTopLevel()`+`goBack()` together.
+
+## Impact
+
+Every fresh login hits the affected path — this is not an edge case. A user who logs in, sees
+the Select Project screen, and wants to back out (wrong server, wrong account, changed their
+mind) has no way to do so via back gesture/button; they'd need to force-quit the app. The
+session-wipe side effect firing silently on every such back press (see Findings) is a secondary,
+less visible concern — it doesn't corrupt anything (the session was going to be abandoned anyway
+in intent), but a user mashing back expecting *something* to happen may end up in a logged-out
+state without understanding why, if they eventually give up and force-quit/relaunch.
+
+No workaround exists from the Select Project screen itself once `isFromLogin=true` — the only way
+out is to complete project selection (pick any project) or force-quit the app.
+
+## Open questions
+
+- Not reproduced live on an emulator in this pass — recommend confirming with the
+  **emulator-testing** skill before landing a fix, both for the current broken state and for
+  whichever fix is chosen.
+- Whether any other top-level screen has a similar "back past the top-level boundary on this
+  specific instance" pattern was checked (grepped every `NavigationBackHandler`/`isBackEnabled`
+  call site) — `ProjectSelectorScreen` is the only one wired to a plain `navigator.goBack()` where
+  the *destination* is itself a top-level key; every other `NavigationBackHandler` site
+  (`UserStoryDetailsScreen`, `TaskDetailsScreen`, `EpicDetailsScreen`, `IssueDetailsScreen`,
+  `SprintScreen`, the `WorkItemEdit*` screens) is a leaf screen whose `goBack()` pops a sub-stack,
+  unaffected by `goToTopLevel()`'s behavior either way.
+
+## Options
+
+**A. Give `Navigator` an explicit "step out of the top-level boundary" primitive**, and have
+`ProjectSelectorScreen`'s login-abandon path call it instead of plain `goBack()`. E.g.
+`Navigator.exitToStart()` (or similarly named) that always does what the old push-based
+`goBack()` did for this one case: land on `startKey` (`Login`). Concretely: set
+`topLevelStack[lastIndex] = state.startKey`, mirroring `resetSubStackTo`'s replace shape, but
+targeting the start key regardless of what's currently active.
+- Pros: keeps revisit #51's fix intact for every drawer section (no reintroduced cascading);
+  gives the login-abandon feature a primitive whose contract actually matches what it needs
+  ("cancel login, return to Login") rather than piggybacking on generic back-stack popping.
+- Cons: adds a second "step back to start" method alongside `resetTo()`/`goBack()` — another
+  `Navigator` primitive to document and test. Only one call site needs it today.
+- Risk/blast radius: contained to `Navigator.kt` + `ProjectSelectorScreen.kt`; doesn't touch
+  `goToTopLevel()`'s general shape, so #51 stays fixed for everything else.
+
+**B. Make `ProjectSelectorScreen`'s `goBack` call site closer to what it actually means**: since
+`isFromLogin` only exists to gate this one behavior, replace the `NavigationBackHandler` + plain
+`navigator.goBack()` combination with a direct call — e.g. `navigator.resetTo(LoginNavDestination)`
+(already exists, already tested) instead of relying on `goBack()`'s stack-popping side effect.
+- Pros: no new `Navigator` API; reuses `resetTo()`, which already wipes every section's history —
+  arguably more correct than the old behavior, since abandoning login should probably not leave
+  stale sub-stack history sitting in other sections either (the old push-based `goBack()` only
+  popped `topLevelStack`, it never touched `subStacks` contents).
+- Cons: behavior change beyond "restore the old back button" — `resetTo()` wipes *every* section's
+  sub-stack, not just `topLevelStack`'s entry; if any section had accumulated state before login
+  (unlikely, since Login/ProjectSelector are the only reachable screens pre-project-selection, but
+  worth confirming), this is a slightly bigger reset than before.
+- Risk/blast radius: contained to `ProjectSelectorScreen.kt`'s `goBack` handling; no `Navigator`
+  API change at all.
+
+**C. Do nothing / won't fix.** Not viable — this blocks a real, common user action (backing out
+of a fresh login) with no workaround. Listed for completeness only.
+
+## Recommendation
+
+**Option B.** It fixes the regression with zero new `Navigator` surface, reuses an already-tested
+primitive (`resetTo()`, covered by `NavigatorTest.kt`'s `resetTo wipes every section...` case),
+and its "wipe everything, not just the top-level slot" behavior is arguably the *more* correct
+interpretation of "abandon this login" than the old code's narrower pop ever was — there's no
+legitimate reason for any section to carry meaningful state before a project has even been
+selected. Concretely: in `ProjectSelectorScreen.kt`, change both the `NavigationIconConfig.Back`
+`onBackClick` (line 84-89) and the `NavigationBackHandler`'s `onBackCompleted` (line 103-106) from
+`{ state.onGoingBackAfterLogIn(); goBack() }` to a new `onCancelLogin: () -> Unit` param that the
+`MainNavHost.kt` call site wires to `{ navigator.resetTo(LoginNavDestination) }` (keeping
+`state.onGoingBackAfterLogIn()` called first, unchanged) — leaving the existing `goBack` param
+free for a future non-login-abandon use, and not overloading it with two meanings.
+
+Option A is the fallback if gregory would rather keep `goBack()` as the single navigation exit
+point from this screen and add the primitive at the `Navigator` layer instead.
+
+## Decision
+
+**Option B, chosen by gregory (2026-09-08).** Rewire `MainNavHost.kt`'s `ProjectSelectorScreen`
+call site so its `goBack` param calls `navigator.resetTo(LoginNavDestination)` instead of
+`navigator.goBack()` — no `ProjectSelectorScreen.kt`/`ProjectSelectorState.kt` change needed,
+since `goBack` is only ever invoked on the `isFromLogin` path already (the non-login path shows
+`NavigationIconConfig.Menu` and has `isBackEnabled = false`, so `goBack` is otherwise dead there).
+
+One part, no test scaffolding exists for `MainNavHost`'s composable wiring (Nav3 graph, not a
+unit-tested layer) — verify live via the **emulator-testing** skill: fresh login → Select Project
+→ back gesture/button lands on Login (and the session-wipe still fires, unchanged); already-logged-in
+→ drawer → Select Project → back still exits the app (this path is untouched by the fix); and a
+quick re-check that ordinary drawer section switching (the PR #392 fix) still doesn't cascade.
+
+## What landed
+
+Changed `MainNavHost.kt`'s `ProjectSelectorNavDestination` entry: `goBack` now calls
+`navigator.resetTo(LoginNavDestination)` instead of `navigator.goBack()`, with a comment
+explaining why (only fires on the `isFromLogin` path, and `goBack()` has nowhere left to pop to
+under PR #392's replace-not-push `topLevelStack`). No change to `ProjectSelectorScreen.kt`,
+`ProjectSelectorState.kt`, or `Navigator.kt` — the fix is entirely at the call site.
+
+Verified with `./gradlew jvmTest` (full suite green, no test asserted the old behavior) and
+`./gradlew :composeApp:ktlintCommonMainSourceSetCheck` (clean), then live on
+`Medium_Phone_API_36.1` (fdroid debug build) against the local Taiga instance:
+
+1. Fresh install → login → Select Project → back button: now lands back on Login (session-wipe
+   confirmed indirectly — logging in again required the full flow, including re-accepting the
+   unencrypted-connection dialog, rather than resuming a live session).
+2. Logged in → drawer → Select Project → back button: still exits the app to the home screen,
+   unaffected (this path was never broken).
+3. Regression check on PR #392: Dashboard → drawer Epics → drawer Issues → back button: still
+   exits the app, does not cascade back to Epics.
+
+Nothing deliberately left out — this was a one-line regression with a one-line fix.

--- a/docs/revisit.md
+++ b/docs/revisit.md
@@ -22,7 +22,6 @@ now that the table below covers everything left.
 | 45 | Tablet nav rail/permanent drawer still has no scroll safety net | S–M | [tablet nav rail issue](issues/2026-08-26-tablet-nav-rail-logout-clipped.md) |
 | 46 | No deep-link readiness plan yet (3 queued Nav3 patterns) | — | [reference-app-scouting.md](../../agentic-grappim/investigations/reference-app-scouting.md) |
 | 47 | `guardrails.yml`'s `push` trigger on `master` still diffs the wrong range after a release merge | S | — |
-| 51 | Switching drawer sections is recorded on the back stack, so back cascades through prior sections | S–M | this file |
 | 52 | No way for a user to send debug logs when filing a bug report | M–L | this file |
 | 53 | Broader excessive-requests audit: possible filter-driven double list-fetch, no search debounce anywhere | S–M | this file |
 
@@ -162,45 +161,6 @@ easily fake-able locally the way `check-guardrails.sh <range>` is.
 guardrails run on `master` failed. If it did (for the reason above, not a real new violation), fix
 the `else` branch the same way: when the event is a push to `master` and `before` is not an ancestor
 of `dev`'s current tip reachable within the release-only commits, use `dev`'s merge-base instead.
-
-## 51. Switching drawer sections is recorded on the back stack, so back cascades through prior sections
-
-**Where:** `core/navigation/src/commonMain/kotlin/com/grappim/taigamobile/core/navigation/Navigator.kt`
-— `goToTopLevel()` (lines 92-107) and `goBack()` (lines 35-47);
-`core/navigation/src/commonMain/kotlin/com/grappim/taigamobile/core/navigation/NavigationState.kt:28-33`
-(`topLevelStack: NavBackStack<NavKey>`, `currentTopLevelKey = topLevelStack.last()`).
-
-**What:** reported by gregory (2026-09-07): navigate Epics → Issues via the drawer, then press back —
-lands on Epics instead of wherever was open before Epics (or exiting the app), which reads as
-unexpected. Traced to the mechanism: `topLevelStack` is a real stack, not a "currently selected
-section" pointer. `goToTopLevel(key)` (`Navigator.kt:92-99`) removes any existing entry for that
-section's class then `add(key)s` it — so switching sections *pushes*, it doesn't replace. `goBack()`
-(`Navigator.kt:35-41`) pops `topLevelStack` whenever the current screen is itself the top of its
-section's sub-stack, so a chain of drawer taps (Epics → Issues → Kanban → …) builds a stack of
-sections that back walks through one at a time, most-recent-first, before ever reaching whatever was
-open before the first drawer tap. `NavigationState.kt:20-21`'s own doc comment confirms this is by
-design ("`topLevelStack` records which drawer section is active"), not an oversight — but it's a
-different UX model than the typical drawer/bottom-nav pattern (Android's own bottom-nav guidance,
-most drawer apps) where switching top-level destinations does *not* grow the back stack and back
-either returns to the single previous screen or exits.
-
-**Consequence:** every drawer navigation the user makes silently extends how many back-presses it
-takes to leave the app, and the "previous section" back lands on is whichever was tapped most
-recently — not necessarily the one the user thinks of as "before this."
-
-**Why deferred:** UX behavior change to a core, deliberately-designed piece of shared navigation
-infrastructure (`Navigator`/`NavigationState` back all top-level nav — drawer, rail, permanent drawer
-across phone/tablet/desktop per the tablet-form-factor-support work), not something to redesign as a
-side note. Needs a decision on the intended model, not just a code change.
-
-**Fix, if wanted:** the conventional alternative is what `resetSubStackTo()` already does for
-re-tapping the *active* section (`Navigator.kt:109-116`, `topLevelStack[lastIndex] = key` — replace,
-not push) — applying the same replace-not-push shape to `goToTopLevel()` would make switching
-sections never grow `topLevelStack` past whatever depth it already had, so back would skip past
-previously-visited sections entirely and go straight to wherever the user was before entering the
-drawer flow (or exit, if that was the start destination). Confirm with gregory this is the wanted
-model before changing it — the current design may be intentional to let users "walk back" through
-their drawer navigation history, which is also a defensible choice some apps make deliberately.
 
 ## 52. No way for a user to send debug logs when filing a bug report
 


### PR DESCRIPTION
## Summary
- `Navigator.goToTopLevel()` pushed each switched-to drawer section onto `topLevelStack`, so `goBack()` walked back through every previously-visited section (most-recent-first) instead of exiting or returning to whatever was open before the drawer flow. Reported by gregory, tracked as `revisit.md` entry 51.
- Fixed by mirroring `resetSubStackTo()`'s replace-not-push shape: `goToTopLevel()` now writes the new key into `topLevelStack`'s existing slot instead of appending. Switching sections no longer grows the stack, so `goBack()`/`canGoBack()` correctly treat any section's root as unhandled (falls through to system/exit).
- Removed the now-unnecessary `startKey` special-case clear in `goToTopLevel()` — replace already keeps the stack at whatever depth it had, regardless of target section.
- **Follow-up fix**: that change was a regression for `ProjectSelectorScreen`'s login-abandon back handling, which relied on the old push behavior (`goBack()` popping `[Login, ProjectSelector]` back to `[Login]`) — so back did nothing on the Select Project screen right after a fresh login. Rewired `MainNavHost`'s `ProjectSelectorScreen` call site to `navigator.resetTo(LoginNavDestination)` instead. Full investigation and root cause in `docs/issues/2026-09-08-project-selector-back-after-login-does-nothing.md`.

## Test plan
- [x] Updated `NavigatorTest.kt` (6 tests renamed/rewritten to assert replace-not-push semantics)
- [x] `./gradlew jvmTest` — full suite green, no cross-module fallout
- [x] `./gradlew :core:navigation:ktlintCommonMainSourceSetCheck :core:navigation:ktlintCommonTestSourceSetCheck` / `:composeApp:ktlintCommonMainSourceSetCheck` — clean
- [x] `.github/scripts/check-guardrails.sh` — nothing tripped
- [x] Verified live on `Medium_Phone_API_36.1` (fdroid debug) against the local Taiga instance: fresh login → Select Project → back now lands on Login; already-logged-in → drawer → Select Project → back still exits the app; Epics → Issues via drawer → back still exits without cascading

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCffTr4Jvw4U7kp4aGkcVu