### PR TITLE
chore(nav): bump grappim-kit-navigation to 0.1.3, drop app-level workaround

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,25 +225,27 @@ on return — see `EpicNavGraph.kt`/`EpicDetailsScreen.kt` for the pattern) must
 primary way users leave the screen — silently bypasses it. Confirmed 2026-09-02: `WikiPageScreen`
 used the bare form and its `UpdateDataOnBack` send never fired from the back arrow.
 
-**`resetTo()`/`goToTopLevel()` do not reset a top-level screen's ViewModel — they only reset
-which nav key is showing.** Every `TOP_LEVEL_KEYS` entry (`MainAppState.kt`) except
-`ProjectSelectorNavDestination` is a payload-less `data object` singleton. Both functions write
-that same singleton back into a `NavBackStack` slot rather than removing the old entry and
-pushing a new one — real Nav3's `ViewModelStoreNavEntryDecorator` only disposes a screen's
-`ViewModelStore` when its key structurally *disappears* from the tracked backstack (confirmed by
-reading `navigation3-runtime`/`lifecycle-viewmodel-navigation3` sources directly — see
-`agentic-grappim`'s `mobile-patterns` skill, Navigation section, for the full mechanism), so
-writing the same singleton back never registers as a change and the `ViewModelStore` — and
-therefore the `@KoinViewModel` resolved against it — survives indefinitely. This is what made
-`DashboardViewModel` keep showing a previous account's data after logout→login until a manual
-refresh (`docs/issues/2026-09-09-account-switch-stale-data-flash-and-refresh-failure.md`).
-Fixed 2026-09-09 by wrapping `MainScreen.kt`'s `MainScreenContent` body (from
-`rememberMainAppState()` down) in `key(sessionGeneration)`, bumped on logout — a Compose-level
-`key()` change fully tears down and rebuilds the subtree (every section's `ViewModelStoreProvider`
-included) regardless of Nav3's own pop-detection. Also flagged as a known, not-yet-fixed issue in
-`grappim-kit/CONSUMING.md`'s navigation section for other consumers of the shared library. **A GUI
-check that force-stops the app between logins cannot catch this** — a fresh process never had the
-stale instance to begin with; verification needs two logins inside one continuous process.
+**`resetTo()` fully disposes every top-level screen's ViewModel, not just whichever section's
+sub-stack actually lost entries.** Every `TOP_LEVEL_KEYS` entry (`MainAppState.kt`) except
+`ProjectSelectorNavDestination` is a payload-less `data object` singleton, and writing that same
+singleton back into a `NavBackStack` slot is invisible to Nav3's own `ViewModelStoreNavEntryDecorator`,
+which only disposes a `ViewModelStore` when a key structurally *disappears* from the tracked
+backstack — this made `DashboardViewModel` keep showing a previous account's data after
+logout→login until a manual refresh
+(`docs/issues/2026-09-09-account-switch-stale-data-flash-and-refresh-failure.md`). Fixed at the
+library level in `grappim-kit-navigation` 0.1.3: `NavigationState` gained a `resetGeneration`
+counter that `resetTo()` bumps, and `toEntries()` wraps its per-section decoration in
+`key(resetGeneration)`, forcing Compose to discard and recreate every section's decorators (and
+therefore their `ViewModelStore`s) on a reset regardless of whether any individual key's identity
+changed. `navigate()`/`goToTopLevel()`/`goBack()` never touch it — ordinary tab-switch/back state
+preservation is unaffected, and `goToTopLevel()` was never actually part of this bug (preserving a
+section's state across a switch is intended behavior). This app's own interim workaround —
+wrapping `MainScreen.kt`'s `MainScreenContent` body in an app-level `key(sessionGeneration)`,
+landed 2026-09-09 — was removed the same day once 0.1.3 shipped; `MainScreen.kt`'s logout handler
+now just calls `navigator.resetTo(LoginNavDestination)` directly, relying on the library fix.
+**A GUI check that force-stops the app between logins cannot catch a regression here** — a fresh
+process never had the stale instance to begin with; verification needs two logins inside one
+continuous process.
 
 ## ViewModel + State Pattern
 

--- a/composeApp/src/commonMain/kotlin/com/grappim/taigamobile/main/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/grappim/taigamobile/main/MainScreen.kt
@@ -21,12 +21,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.key
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -44,6 +40,7 @@ import com.grappim.taigamobile.DrawerDestination
 import com.grappim.taigamobile.TaigaDrawerWidget
 import com.grappim.taigamobile.TaigaNavigationSuiteWidget
 import com.grappim.taigamobile.core.logger.logcat
+import com.grappim.taigamobile.feature.login.ui.LoginNavDestination
 import com.grappim.taigamobile.strings.RString
 import com.grappim.taigamobile.strings.generated.resources.close
 import com.grappim.taigamobile.uikit.state.LocalOfflineState
@@ -81,149 +78,136 @@ private fun MainScreenContent(
     initialNavState: InitialNavState,
     isOffline: Boolean
 ) {
-    // Bumped on every logout so the key(sessionGeneration) block below is torn down and rebuilt
-    // from scratch — Nav3's ViewModelStoreNavEntryDecorator only disposes a top-level screen's
-    // ViewModelStore when that screen's key structurally disappears from its own sub-stack, and
-    // every top-level key (DashboardNavDestination, EpicsNavDestination, ...) is a singleton
-    // `data object`, so resetTo()/goToTopLevel() writing that same object back never registers as
-    // a change. Without this, every top-level screen's ViewModel survives logout/login and keeps
-    // showing whichever account loaded it first. rememberSaveable so a process death mid-session
-    // (generation > 0) restores against the same composite key its back stack was saved under,
-    // instead of silently losing the deeper back stack because generation reset to 0.
-    var sessionGeneration by rememberSaveable { mutableIntStateOf(0) }
+    val appState = rememberMainAppState()
+
+    val scope = rememberCoroutineScope()
+    val drawerState by appState.drawerState.collectAsStateWithLifecycle()
+    val drawerItems by viewModel.drawerItems.collectAsStateWithLifecycle()
+
+    val snackbarHostState = remember { SnackbarHostState() }
 
     LaunchedEffect(Unit) {
         viewModel.logoutEvent.onEach {
             logcat {
                 "Logout Event with $it"
             }
-            sessionGeneration++
+            appState.navigator.resetTo(LoginNavDestination)
         }.launchIn(this)
     }
 
-    key(sessionGeneration) {
-        val appState = rememberMainAppState()
+    HideKeyboardOnNavigationChangeEffect(navigationState = appState.navigator.state)
 
-        val scope = rememberCoroutineScope()
-        val drawerState by appState.drawerState.collectAsStateWithLifecycle()
-        val drawerItems by viewModel.drawerItems.collectAsStateWithLifecycle()
+    val snackbarActionLabel = stringResource(RString.close)
 
-        val snackbarHostState = remember { SnackbarHostState() }
-
-        HideKeyboardOnNavigationChangeEffect(navigationState = appState.navigator.state)
-
-        val snackbarActionLabel = stringResource(RString.close)
-
-        val onDrawerItemClick: (DrawerDestination) -> Unit = { item ->
-            scope.launch {
-                drawerState.close()
-            }
-            appState.navigateToTopLevelDestination(item)
+    val onDrawerItemClick: (DrawerDestination) -> Unit = { item ->
+        scope.launch {
+            drawerState.close()
         }
+        appState.navigateToTopLevelDestination(item)
+    }
 
-        val mainContent: @Composable () -> Unit = {
-            Scaffold(
-                modifier = Modifier.imePadding(),
-                topBar = {
-                    TopBar(
-                        isVisible = appState.isTopBarVisible,
-                        topBarConfig = topBarConfig,
-                        drawerState = drawerState,
-                        defaultGoBack = { appState.navigator.goBack() },
-                        backContentDescription = "Back",
-                        menuContentDescription = "Menu"
+    val mainContent: @Composable () -> Unit = {
+        Scaffold(
+            modifier = Modifier.imePadding(),
+            topBar = {
+                TopBar(
+                    isVisible = appState.isTopBarVisible,
+                    topBarConfig = topBarConfig,
+                    drawerState = drawerState,
+                    defaultGoBack = { appState.navigator.goBack() },
+                    backContentDescription = "Back",
+                    menuContentDescription = "Menu"
+                )
+            },
+            snackbarHost = {
+                SnackbarHost(
+                    modifier = Modifier.windowInsetsPadding(WindowInsets.safeDrawing),
+                    hostState = snackbarHostState
+                ) {
+                    Snackbar(
+                        snackbarData = it,
+                        shape = MaterialTheme.shapes.small,
+                        containerColor = MaterialTheme.colorScheme.surface,
+                        contentColor = contentColorFor(MaterialTheme.colorScheme.surface)
                     )
-                },
-                snackbarHost = {
-                    SnackbarHost(
-                        modifier = Modifier.windowInsetsPadding(WindowInsets.safeDrawing),
-                        hostState = snackbarHostState
-                    ) {
-                        Snackbar(
-                            snackbarData = it,
-                            shape = MaterialTheme.shapes.small,
-                            containerColor = MaterialTheme.colorScheme.surface,
-                            contentColor = contentColorFor(MaterialTheme.colorScheme.surface)
-                        )
-                    }
-                },
-                content = { paddingValues ->
-                    Column(modifier = Modifier.padding(paddingValues)) {
-                        OfflineIndicatorBanner(isOffline = isOffline)
+                }
+            },
+            content = { paddingValues ->
+                Column(modifier = Modifier.padding(paddingValues)) {
+                    OfflineIndicatorBanner(isOffline = isOffline)
 
-                        MainNavHost(
-                            initialNavState = initialNavState,
-                            navigator = appState.navigator,
-                            navigationState = appState.navigator.state,
-                            showSnackbar = { text ->
-                                scope.launch {
-                                    val result = snackbarHostState.showSnackbar(
-                                        message = text.asStringBlocking(),
-                                        actionLabel = snackbarActionLabel,
-                                        duration = SnackbarDuration.Short
-                                    )
-                                    if (result == SnackbarResult.ActionPerformed) {
-                                        snackbarHostState.currentSnackbarData?.dismiss()
-                                    }
+                    MainNavHost(
+                        initialNavState = initialNavState,
+                        navigator = appState.navigator,
+                        navigationState = appState.navigator.state,
+                        showSnackbar = { text ->
+                            scope.launch {
+                                val result = snackbarHostState.showSnackbar(
+                                    message = text.asStringBlocking(),
+                                    actionLabel = snackbarActionLabel,
+                                    duration = SnackbarDuration.Short
+                                )
+                                if (result == SnackbarResult.ActionPerformed) {
+                                    snackbarHostState.currentSnackbarData?.dismiss()
                                 }
                             }
-                        )
+                        }
+                    )
+                }
+            }
+        )
+    }
+
+    val windowAdaptiveInfo = currentWindowAdaptiveInfoV2()
+    val isCompactWidth = !windowAdaptiveInfo.windowSizeClass
+        .isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_MEDIUM_LOWER_BOUND)
+
+    if (isCompactWidth) {
+        TaigaDrawerWidget(
+            drawerItems = drawerItems,
+            currentTopLevelDestination = appState.currentTopLevelDestination,
+            drawerState = drawerState,
+            onDrawerItemClick = onDrawerItemClick,
+            gesturesEnabled = appState.areDrawerGesturesEnabled &&
+                initialNavState.isReady &&
+                initialNavState.isProjectSelected
+        ) {
+            mainContent()
+
+            /**
+             * It is required to place it below MainNavHost because as per documentation
+             * "If multiple BackHandler are present in the composition,
+             * the one that is composed last among all enabled handlers will be invoked."
+             * And with that this one will be called, otherwise on clicking back
+             * we will go back in navigation but drawer will stay opened
+             *
+             * The second condition drawerState.isAnimationRunning is needed to fix an issue
+             * when the drawer is visibly fully opened but is not opened actually
+             *
+             * Only needed for the modal drawer above: a rail/permanent drawer has no open/close
+             * animation state for back to intercept.
+             */
+            NavigationBackHandler(
+                state = rememberNavigationEventState(NavigationEventInfo.None),
+                isBackEnabled = drawerState.isOpen || drawerState.isAnimationRunning,
+                onBackCompleted = {
+                    scope.launch {
+                        drawerState.close()
                     }
                 }
             )
         }
-
-        val windowAdaptiveInfo = currentWindowAdaptiveInfoV2()
-        val isCompactWidth = !windowAdaptiveInfo.windowSizeClass
-            .isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_MEDIUM_LOWER_BOUND)
-
-        if (isCompactWidth) {
-            TaigaDrawerWidget(
-                drawerItems = drawerItems,
-                currentTopLevelDestination = appState.currentTopLevelDestination,
-                drawerState = drawerState,
-                onDrawerItemClick = onDrawerItemClick,
-                gesturesEnabled = appState.areDrawerGesturesEnabled &&
-                    initialNavState.isReady &&
-                    initialNavState.isProjectSelected
-            ) {
-                mainContent()
-
-                /**
-                 * It is required to place it below MainNavHost because as per documentation
-                 * "If multiple BackHandler are present in the composition,
-                 * the one that is composed last among all enabled handlers will be invoked."
-                 * And with that this one will be called, otherwise on clicking back
-                 * we will go back in navigation but drawer will stay opened
-                 *
-                 * The second condition drawerState.isAnimationRunning is needed to fix an issue
-                 * when the drawer is visibly fully opened but is not opened actually
-                 *
-                 * Only needed for the modal drawer above: a rail/permanent drawer has no open/close
-                 * animation state for back to intercept.
-                 */
-                NavigationBackHandler(
-                    state = rememberNavigationEventState(NavigationEventInfo.None),
-                    isBackEnabled = drawerState.isOpen || drawerState.isAnimationRunning,
-                    onBackCompleted = {
-                        scope.launch {
-                            drawerState.close()
-                        }
-                    }
-                )
-            }
-        } else if (initialNavState.isReady && initialNavState.isProjectSelected) {
-            TaigaNavigationSuiteWidget(
-                drawerItems = drawerItems,
-                currentTopLevelDestination = appState.currentTopLevelDestination,
-                onDrawerItemClick = onDrawerItemClick,
-                layoutType = NavigationSuiteScaffoldDefaults.calculateFromAdaptiveInfo(windowAdaptiveInfo)
-            ) {
-                mainContent()
-            }
-        } else {
+    } else if (initialNavState.isReady && initialNavState.isProjectSelected) {
+        TaigaNavigationSuiteWidget(
+            drawerItems = drawerItems,
+            currentTopLevelDestination = appState.currentTopLevelDestination,
+            onDrawerItemClick = onDrawerItemClick,
+            layoutType = NavigationSuiteScaffoldDefaults.calculateFromAdaptiveInfo(windowAdaptiveInfo)
+        ) {
             mainContent()
         }
+    } else {
+        mainContent()
     }
 }
 

--- a/docs/frictions.md
+++ b/docs/frictions.md
@@ -84,3 +84,6 @@ deleted — see `finalize`.
   or popping one nav level — cost a recovery detour (tap SKIP, `am force-stop` + relaunch). Root
   cause not diagnosed; avoid `KEYCODE_BACK` as a generic "undo my last tap" move on this AVD and
   re-screenshot after any BACK before assuming it stayed in-app.
+- 2026-09-09: `gh pr edit` (title/body) failed with a GraphQL "Projects (classic) is being
+  deprecated" error on this repo regardless of what fields were passed — worked around with
+  `gh api repos/<owner>/<repo>/pulls/<n> -X PATCH -f title=... -f body=...` instead.

--- a/docs/issues/2026-09-09-account-switch-stale-data-flash-and-refresh-failure.md
+++ b/docs/issues/2026-09-09-account-switch-stale-data-flash-and-refresh-failure.md
@@ -498,3 +498,9 @@ instead of each app needing its own `key(sessionGeneration)` workaround. Flagged
 gregory in the options above; not actioned here per CLAUDE.md's grappim-kit swap
 guidance (needs its own investigation into whether other consumers rely on today's
 behavior, and its own go-ahead).
+
+**Follow-up closed 2026-09-09:** Option E landed upstream — `grappim-kit-navigation` 0.1.3 fixes
+`resetTo()` itself via a `resetGeneration` counter (`goToTopLevel()` confirmed never part of the
+bug). This app's `key(sessionGeneration)` workaround was removed the same day once the app bumped
+onto 0.1.3; `MainScreen.kt`'s logout handler now calls `navigator.resetTo(LoginNavDestination)`
+directly. See CLAUDE.md's Navigation Pattern section for the current mechanism.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -86,7 +86,7 @@ jetbrainsSavedState = "1.4.0"
 jetbrainsComposeIcons = "1.7.3"
 jetbrainsAndroidxLifecycle = "2.11.0"
 jetbrainsNav3 = "1.1.1"
-grappimKitNavigation = "0.1.2"
+grappimKitNavigation = "0.1.3"
 grappimKitUikit = "0.1.2"
 
 compose-bom = "2026.08.00"


### PR DESCRIPTION
## Summary
- Bumps `grappim-kit-navigation` 0.1.2 → 0.1.3, picking up the upstream fix for a `ViewModelStore` leak in `Navigator.resetTo()`.
- Root cause upstream: a payload-less singleton `NavKey` (every `TOP_LEVEL_KEYS` entry) is `equals()`-identical before and after `resetTo()` writes it back into a sub-stack slot, so Nav3's structural diffing never sees it "disappear" and never disposes its `ViewModelStore`. Fixed via a `resetGeneration` counter that `resetTo()` bumps and `toEntries()` keys on, forcing a full teardown/rebuild on reset. `navigate()`/`goToTopLevel()`/`goBack()` are untouched — normal tab-switch/back state preservation is unaffected.
- **Removes this app's own `MainScreen.kt` `key(sessionGeneration)` workaround for the same bug** (landed in #399), now that the library handles it directly. The logout handler goes back to calling `navigator.resetTo(LoginNavDestination)` directly — the pre-workaround structure — instead of tearing down and rebuilding the whole nav subtree.
- Updated `CLAUDE.md`'s Navigation Pattern section and `docs/issues/2026-09-09-account-switch-stale-data-flash-and-refresh-failure.md`, both of which documented the removed workaround as current.

## Verification
- `./gradlew jvmTest` — full suite green, including live-Taiga integration tests
- `./gradlew ktlintCheck` — clean
- `./gradlew koverXmlReport :koverVerify` — coverage floor holds
- `.github/scripts/check-guardrails.sh origin/dev..HEAD` — nothing tripped

## Test plan
- [ ] gregory: device-test on desktop/emulator before merging — logout → login, confirm no stale account data (same manual check as #399), same convention as #393/#394

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143sx9A44L4XQsFeWCuWQb6