### PR TITLE
fix(ci): drop preinstalled google-chrome apt source in desktop-package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,6 +127,11 @@ jobs:
       - name: Setup Android Environment
         uses: ./.github/actions/android-setup-composite-action
 
+      - name: Debug apt sources
+        run: |
+            ls -la /etc/apt/sources.list.d/
+            grep -rH "dl.google.com" /etc/apt/sources.list.d/ /etc/apt/sources.list || true
+
       - name: Install fakeroot and rpm
         run: |
             sudo rm -f /etc/apt/sources.list.d/google-chrome.list

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,14 +127,9 @@ jobs:
       - name: Setup Android Environment
         uses: ./.github/actions/android-setup-composite-action
 
-      - name: Debug apt sources
-        run: |
-            ls -la /etc/apt/sources.list.d/
-            grep -rH "dl.google.com" /etc/apt/sources.list.d/ /etc/apt/sources.list || true
-
       - name: Install fakeroot and rpm
         run: |
-            sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+            sudo rm -f /etc/apt/sources.list.d/google-chrome.sources
             sudo apt-get update
             sudo apt-get install -y fakeroot rpm
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,6 +129,7 @@ jobs:
 
       - name: Install fakeroot and rpm
         run: |
+            sudo rm -f /etc/apt/sources.list.d/google-chrome.list
             sudo apt-get update
             sudo apt-get install -y fakeroot rpm
 


### PR DESCRIPTION
## Summary
- `desktop-package`'s "Install fakeroot and rpm" step was failing `sudo apt-get update` with a Hash Sum mismatch on the runner-preinstalled `google-chrome.list` apt source (a CDN metadata race on Google's side, unrelated to this repo's code). Confirmed on PR #406 and PR #408, same step, same ~17:44Z window, no shared code change.
- The job never installs anything from that source, so remove it before `apt-get update` instead of depending on its checksum being consistent.

## Test plan
- [x] `check-guardrails.sh` passes locally with the `Gate-change:` line
- [ ] `desktop-package` job goes green on this PR's own build.yml run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143sx9A44L4XQsFeWCuWQb6