### PR TITLE
docs: record apt-source gotcha from PR #409 and promote guess-before-verify rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -496,6 +496,17 @@ object locally** — to build against the PR's merge-base (e.g. for a size/perf 
 explicitly: `git fetch --depth=1 origin ${{ github.event.pull_request.base.sha }}` before `git
 checkout` that sha. Confirmed 2026-08-30 in `build.yml`'s `apk-size-check` job.
 
+**`ubuntu-latest`'s preinstalled Google Chrome apt repo can intermittently fail `apt-get update`
+with a Hash Sum mismatch** (a CDN metadata race on Google's end, unrelated to this repo) and abort
+the whole `apt-get update`, breaking any later `apt-get install` in the same step — hit in
+`build.yml`'s `desktop-package` job (`Install fakeroot and rpm`), which doesn't use Chrome at all.
+Fix: `sudo rm -f /etc/apt/sources.list.d/google-chrome.sources` before `apt-get update`. Note the
+filename — it's the newer deb822 format (`.sources`, `URIs:`/`Suites:` keys), not the legacy
+`google-chrome.list` that `actions/runner-images`' own `install-google-chrome.sh` still references;
+guessing the old name is a silent no-op (`rm -f` doesn't error on a missing path) rather than a
+visible failure. Confirmed 2026-09-09 (PR #409) by listing `/etc/apt/sources.list.d/` in a debug
+step rather than guessing twice.
+
 ## Multi-Session Work
 
 For any initiative that spans multiple sessions — a feature investigation, a redesign, a
@@ -687,6 +698,17 @@ procedure by hand — a script or a hook can't skip a step or get one wrong the 
 can. `.github/scripts/check-guardrails.sh` is this project's own example: the gate rules are a
 script, not a mental checklist to re-derive each session. Reserve judgment for what actually needs
 it — ambiguous input, a plan, a choice between options.
+
+**Never guess an external artifact's exact name from convention — list or query the real source
+first.** A filename, URL, or API signature that "should" follow a pattern (a release-asset name
+built from a version tag, an apt source's legacy filename, a sibling function's parameter list)
+routinely doesn't, and a wrong guess that fails silently (e.g. `rm -f` on a missing path) can burn
+a full round-trip before the mismatch is even visible. Confirmed three times: a GitHub release's
+actual asset name vs. one built from the version tag (`docs/frictions.md` 2026-08-29), an
+`androidx` API's real signature vs. a sibling overload's shape (2026-08-15), and a CI runner's
+actual apt source filename vs. the legacy name referenced in its own build script (2026-09-09,
+PR #409) — see the CI Guardrails entry above for that case. Check with `gh api`/`ls`/reading the
+real source before writing the fix, not after it fails once.
 
 ### Goal-Driven Execution
 

--- a/docs/frictions.md
+++ b/docs/frictions.md
@@ -26,13 +26,6 @@ deleted — see `finalize`.
   directly). Not fork-specific; the skill name from CLAUDE.md's table just doesn't resolve via the
   `Skill` tool at all, in any session type. Second occurrence — one more and this needs an actual
   fix, not another line here.
-- 2026-08-15: assumed `NavBackStackEntry.toRoute<T>(typeMap = ...)` existed, copying
-  `SavedStateHandle.toRoute<T>(typeMap = ...)`'s call shape into 6 NavGraph call sites (step 8) —
-  compiler rejected all 6 ("No parameter with name 'typeMap' found"). `NavBackStackEntry.toRoute()`
-  takes no typeMap arg at all; it reads the typeMap the enclosing `composable<T>(typeMap = ...)`
-  already registered on the destination. Confirmed by reading
-  `navigation-common-desktop-2.9.2-sources.jar` directly rather than guessing from the sibling
-  `SavedStateHandle` overload's signature.
 - 2026-08-15: a hand-rolled `CompositionLocal` shaped like androidx's own `LocalResultEventBus`
   (an `object` wrapping a private `compositionLocalOf`) failed `ktlintCheck` twice over
   (`compose:compositionlocal-naming`, `compose:compositionlocal-allowlist`) before switching to a
@@ -61,9 +54,6 @@ deleted — see `finalize`.
   (back-arrow nav and two other buttons all showed it). Gave up after ~10 attempts and verified step
   4's fix via code read + `jvmTest`/`ktlintCheck` instead of a live click-through. Root cause not
   found; worth a fresh look if this blocks a future GUI-verification step.
-- 2026-08-29: guessed `diffuse` 0.3.0 download URL (`diffuse-0.3.0-binary.jar`) 404'd; the release
-  asset is actually a `diffuse-0.3.0.zip` — checked via `gh`/GitHub releases API
-  (`browser_download_url`) instead of guessing the filename pattern from the version tag.
 - 2026-08-30: `pip install pyyaml` reported "already satisfied" but `python3 -c "import yaml"` still
   failed with `ModuleNotFoundError` — this machine's `python3` on PATH resolves to a linuxbrew
   install (3.14) that doesn't see the apt-installed pyyaml under `/usr/lib/python3/dist-packages`.


### PR DESCRIPTION
## Summary
Follow-up to PR #409, which was merged before this doc commit reached the branch — that commit ended up stranded, so it's landing here as its own small PR.

- `CLAUDE.md` CI Guardrails: documents the real `google-chrome.sources` (deb822) apt-source filename vs. the legacy `.list` name that misled the first fix attempt in #409.
- `CLAUDE.md` Coding Guidelines: promotes "never guess an external artifact's exact name from convention — verify against the real source first" as a rule, since this was the third `docs/frictions.md` entry of that shape.
- `docs/frictions.md`: the three promoted entries are removed, per this project's own promotion rule.

## Test plan
- [x] `check-guardrails.sh` passes locally
- Docs-only change, no build/test impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143sx9A44L4XQsFeWCuWQb6