### PR TITLE
chore(deps): sync grappim-kit modules to 0.1.5 and unify version key

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -86,17 +86,7 @@ jetbrainsSavedState = "1.4.0"
 jetbrainsComposeIcons = "1.7.3"
 jetbrainsAndroidxLifecycle = "2.11.0"
 jetbrainsNav3 = "1.1.1"
-grappimKitNavigation = "0.1.4"
-grappimKitUikit = "0.1.5"
-grappimKitLogger = "0.1.4"
-grappimKitCoroutines = "0.1.4"
-grappimKitCrash = "0.1.5"
-grappimKitAppinfo = "0.1.4"
-grappimKitDomain = "0.1.4"
-grappimKitStorage = "0.1.4"
-grappimKitTrustmanager = "0.1.4"
-grappimKitTesting = "0.1.4"
-grappimKitAppupdate = "0.1.4"
+grappimKit = "0.1.5"
 
 compose-bom = "2026.09.00"
 
@@ -159,19 +149,19 @@ jetbrains-compose-icons = { module = "org.jetbrains.compose.material:material-ic
 jetbrains-compose-icons-extended = { module = "org.jetbrains.compose.material:material-icons-extended", version.ref = "jetbrainsComposeIcons" }
 jetbrains-navigation3-ui = { module = "org.jetbrains.androidx.navigation3:navigation3-ui", version.ref = "jetbrainsNav3" }
 jetbrains-lifecycle-viewmodel-navigation3 = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-navigation3", version.ref = "jetbrainsAndroidxLifecycle" }
-grappim-kit-navigation = { module = "io.github.grigoriym:grappim-kit-navigation", version.ref = "grappimKitNavigation" }
-grappim-kit-uikit = { module = "io.github.grigoriym:grappim-kit-uikit", version.ref = "grappimKitUikit" }
-grappim-kit-logger = { module = "io.github.grigoriym:grappim-kit-logger", version.ref = "grappimKitLogger" }
-grappim-kit-coroutines = { module = "io.github.grigoriym:grappim-kit-coroutines", version.ref = "grappimKitCoroutines" }
-grappim-kit-crash = { module = "io.github.grigoriym:grappim-kit-crash", version.ref = "grappimKitCrash" }
-grappim-kit-appinfo = { module = "io.github.grigoriym:grappim-kit-appinfo", version.ref = "grappimKitAppinfo" }
-grappim-kit-domain = { module = "io.github.grigoriym:grappim-kit-domain", version.ref = "grappimKitDomain" }
-grappim-kit-storage = { module = "io.github.grigoriym:grappim-kit-storage", version.ref = "grappimKitStorage" }
-grappim-kit-trustmanager = { module = "io.github.grigoriym:grappim-kit-trustmanager", version.ref = "grappimKitTrustmanager" }
-grappim-kit-testing = { module = "io.github.grigoriym:grappim-kit-testing", version.ref = "grappimKitTesting" }
-grappim-kit-appupdate = { module = "io.github.grigoriym:grappim-kit-appupdate", version.ref = "grappimKitAppupdate" }
-grappim-kit-appupdate-gplay = { module = "io.github.grigoriym:grappim-kit-appupdate-gplay", version.ref = "grappimKitAppupdate" }
-grappim-kit-appupdate-fdroid = { module = "io.github.grigoriym:grappim-kit-appupdate-fdroid", version.ref = "grappimKitAppupdate" }
+grappim-kit-navigation = { module = "io.github.grigoriym:grappim-kit-navigation", version.ref = "grappimKit" }
+grappim-kit-uikit = { module = "io.github.grigoriym:grappim-kit-uikit", version.ref = "grappimKit" }
+grappim-kit-logger = { module = "io.github.grigoriym:grappim-kit-logger", version.ref = "grappimKit" }
+grappim-kit-coroutines = { module = "io.github.grigoriym:grappim-kit-coroutines", version.ref = "grappimKit" }
+grappim-kit-crash = { module = "io.github.grigoriym:grappim-kit-crash", version.ref = "grappimKit" }
+grappim-kit-appinfo = { module = "io.github.grigoriym:grappim-kit-appinfo", version.ref = "grappimKit" }
+grappim-kit-domain = { module = "io.github.grigoriym:grappim-kit-domain", version.ref = "grappimKit" }
+grappim-kit-storage = { module = "io.github.grigoriym:grappim-kit-storage", version.ref = "grappimKit" }
+grappim-kit-trustmanager = { module = "io.github.grigoriym:grappim-kit-trustmanager", version.ref = "grappimKit" }
+grappim-kit-testing = { module = "io.github.grigoriym:grappim-kit-testing", version.ref = "grappimKit" }
+grappim-kit-appupdate = { module = "io.github.grigoriym:grappim-kit-appupdate", version.ref = "grappimKit" }
+grappim-kit-appupdate-gplay = { module = "io.github.grigoriym:grappim-kit-appupdate-gplay", version.ref = "grappimKit" }
+grappim-kit-appupdate-fdroid = { module = "io.github.grigoriym:grappim-kit-appupdate-fdroid", version.ref = "grappimKit" }
 
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlin-serialization-json" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }


### PR DESCRIPTION
## Summary
- Bumps nine drifted `grappimKit*` version-catalog entries (navigation, logger, coroutines, appinfo, domain, storage, trustmanager, testing, appupdate) from `0.1.4` to `0.1.5`, matching `uikit`/`crash` which were already there.
- Collapses the eleven separate `grappimKit*` version keys into a single `grappimKit` key, since grappim-kit publishes one shared `VERSION_NAME` for every wired module together — there's no scenario where these modules are at different versions.

## Verification
- Diffed the `grappim-kit` repo between its 0.1.4 and 0.1.5 tag commits: only `uikit` (drawer widget) and docs changed — none of these nine modules' source differs between the two releases.
- Confirmed all nine coordinates are actually published at `0.1.5` on Maven Central (`maven-metadata.xml`).
- `./gradlew jvmTest`, `ktlintCheck`, `koverXmlReport`/`:koverVerify` (floor holds), and `.github/scripts/check-guardrails.sh` all green.

Requested by a peer session coordinating the grappim-kit rollout; approved directly by gregory before starting.

## Test plan
- [x] `./gradlew jvmTest`
- [x] `./gradlew ktlintCheck`
- [x] `./gradlew koverXmlReport :koverVerify`
- [x] `.github/scripts/check-guardrails.sh origin/dev..HEAD`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MoQ2CSjFhpGU9eJB7Gpcdg