### PR TITLE
chore(deps): bump grappim-kit modules to 0.1.6

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -86,7 +86,7 @@ jetbrainsSavedState = "1.4.0"
 jetbrainsComposeIcons = "1.7.3"
 jetbrainsAndroidxLifecycle = "2.11.0"
 jetbrainsNav3 = "1.1.1"
-grappimKit = "0.1.5"
+grappimKit = "0.1.6"
 
 compose-bom = "2026.09.00"
 


### PR DESCRIPTION
## Summary
- Bumps the shared `grappimKit` version-catalog key to 0.1.6 (all 13 wired modules).
- Triggered by a fix in `grappim-kit-storage`'s `KeystoreSecretCipher.decrypt()`, found by wallosmobile's session: an unprefixed stored value was always treated as legacy plaintext, which corrupted real ciphertext for consumers whose pre-swap cipher never used that prefix.
- Not a behavior change here: TaigaMobileNova's own pre-swap `AndroidKeystoreTokenCipher` already used the identical `"v1:"` prefix/passthrough convention, so the new `legacyUnprefixedIsPlaintext` constructor param (default `true`) preserves current behavior exactly.

## Test plan
- [x] `./gradlew jvmTest --rerun` — full suite green on 0.1.6